### PR TITLE
Fix BaseHtmlElement

### DIFF
--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -179,15 +179,4 @@ abstract class BaseHtmlElement extends HtmlDocument
 
         return $this;
     }
-
-    /**
-     * Whether the given something can be rendered
-     *
-     * @param mixed $any
-     * @return bool
-     */
-    protected function canBeRendered($any)
-    {
-        return is_string($any) || is_int($any) || is_null($any);
-    }
 }

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -2,6 +2,8 @@
 
 namespace ipl\Html;
 
+use RuntimeException;
+
 abstract class BaseHtmlElement extends HtmlDocument
 {
     /** @var array You may want to set default attributes when extending this class */
@@ -124,14 +126,14 @@ abstract class BaseHtmlElement extends HtmlDocument
      *
      * @return  string
      *
-     * @throws  \RuntimeException   If the element does not have a tag
+     * @throws  RuntimeException   If the element does not have a tag
      */
     final public function getTag()
     {
         $tag = $this->tag();
 
         if (! strlen($tag)) {
-            throw new \RuntimeException('Element must have a tag');
+            throw new RuntimeException('Element must have a tag');
         }
 
         return $tag;
@@ -185,7 +187,7 @@ abstract class BaseHtmlElement extends HtmlDocument
     /**
      * @inheritdoc
      *
-     * @throws  \RuntimeException   If the element does not have a tag or is void but has content
+     * @throws  RuntimeException   If the element does not have a tag or is void but has content
      */
     public function renderUnwrapped()
     {
@@ -197,8 +199,7 @@ abstract class BaseHtmlElement extends HtmlDocument
 
         if (! $this->wantsClosingTag()) {
             if (strlen($content)) {
-                // @TODO(el): Should we add a dedicated exception class?
-                throw new \RuntimeException('Void elements must not have content');
+                throw new RuntimeException('Void elements must not have content');
             }
 
             return sprintf('<%s%s />', $tag, $attributes);
@@ -247,8 +248,6 @@ abstract class BaseHtmlElement extends HtmlDocument
      * If you want to override this behavior, use {@link setVoid()}.
      *
      * @return  bool
-     *
-     * @throws  \RuntimeException   If the element does not have a tag
      */
     public function isVoid()
     {

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -13,6 +13,15 @@ abstract class BaseHtmlElement extends HtmlDocument
     /** @var string */
     protected $tag;
 
+    /**
+     * List of void elements which must not contain end tags or content
+     *
+     * This property should be used to decide whether the content and end tag has to be rendered.
+     *
+     * @var array
+     *
+     * @see https://www.w3.org/TR/html5/syntax.html#void-elements
+     */
     protected static $voidElements = [
         'area',
         'base',

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -117,7 +117,34 @@ abstract class BaseHtmlElement extends HtmlDocument
         return $this->defaultAttributes;
     }
 
-    public function getTag()
+    /**
+     * Get the tag of the element
+     *
+     * Since HTML Elements must have a tag, this method throws an exception if the element does not have a tag.
+     *
+     * @return  string
+     *
+     * @throws  \RuntimeException   If the element does not have a tag
+     */
+    final public function getTag()
+    {
+        $tag = $this->tag();
+
+        if (! strlen($tag)) {
+            throw new \RuntimeException('Element must have a tag');
+        }
+
+        return $tag;
+    }
+
+    /**
+     * Internal method for accessing the tag
+     *
+     * You may override this method in order to provide the tag dynamically
+     *
+     * @return  string
+     */
+    protected function tag()
     {
         return $this->tag;
     }
@@ -158,7 +185,7 @@ abstract class BaseHtmlElement extends HtmlDocument
     /**
      * @inheritdoc
      *
-     * @throws  \RuntimeException   If the element is void but has content
+     * @throws  \RuntimeException   If the element does not have a tag or is void but has content
      */
     public function renderUnwrapped()
     {
@@ -220,6 +247,8 @@ abstract class BaseHtmlElement extends HtmlDocument
      * If you want to override this behavior, use {@link setVoid()}.
      *
      * @return  bool
+     *
+     * @throws  \RuntimeException   If the element does not have a tag
      */
     public function isVoid()
     {

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -175,10 +175,10 @@ abstract class BaseHtmlElement extends HtmlDocument
     public function wantsClosingTag()
     {
         // TODO: There is more. SVG and MathML namespaces
-        return ! $this->isVoidElement();
+        return ! $this->isVoid();
     }
 
-    public function isVoidElement()
+    public function isVoid()
     {
         if ($this->isVoid !== null) {
             return $this->isVoid;

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -23,20 +23,20 @@ abstract class BaseHtmlElement extends HtmlDocument
      * @see https://www.w3.org/TR/html5/syntax.html#void-elements
      */
     protected static $voidElements = [
-        'area',
-        'base',
-        'br',
-        'col',
-        'embed',
-        'hr',
-        'img',
-        'input',
-        'link',
-        'meta',
-        'param',
-        'source',
-        'track',
-        'wbr'
+        'area'   => 1,
+        'base'   => 1,
+        'br'     => 1,
+        'col'    => 1,
+        'embed'  => 1,
+        'hr'     => 1,
+        'img'    => 1,
+        'input'  => 1,
+        'link'   => 1,
+        'meta'   => 1,
+        'param'  => 1,
+        'source' => 1,
+        'track'  => 1,
+        'wbr'    => 1
     ];
 
     protected $isVoid;
@@ -180,11 +180,13 @@ abstract class BaseHtmlElement extends HtmlDocument
 
     public function isVoidElement()
     {
-        if ($this->isVoid === null) {
-            $this->isVoid = in_array($this->getTag(), self::$voidElements);
+        if ($this->isVoid !== null) {
+            return $this->isVoid;
         }
 
-        return $this->isVoid;
+        $tag = $this->getTag();
+
+        return isset(self::$voidElements[$tag]);
     }
 
     public function setVoid($void = true)

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -16,7 +16,8 @@ abstract class BaseHtmlElement extends HtmlDocument
     /**
      * List of void elements which must not contain end tags or content
      *
-     * This property should be used to decide whether the content and end tag has to be rendered.
+     * If {@link $isVoid} is null, this property should be used to decide whether the content and end tag has to be
+     * rendered.
      *
      * @var array
      *
@@ -39,10 +40,13 @@ abstract class BaseHtmlElement extends HtmlDocument
         'wbr'    => 1
     ];
 
+    /** @var bool|null Whether the element is void. If null, void check should use {@link $voidElements} */
     protected $isVoid;
 
     /**
-     * @return Attributes
+     * Get the attributes of the element
+     *
+     * @return  Attributes
      */
     public function getAttributes()
     {
@@ -59,8 +63,11 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
-     * @param Attributes|array|null $attributes
-     * @return $this
+     * Set the attributes of the element
+     *
+     * @param   Attributes|array|null   $attributes
+     *
+     * @return  $this
      */
     public function setAttributes($attributes)
     {
@@ -70,9 +77,14 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
-     * @param string $key
-     * @param mixed $value
-     * @return $this
+     * Set the attribute with the given name and value
+     *
+     * If the attribute with the given name already exists, it gets overridden.
+     *
+     * @param   string              $key    The name of the attribute
+     * @param   string|bool|array   $value  The value of the attribute
+     *
+     * @return  $this
      */
     public function setAttribute($key, $value)
     {
@@ -82,8 +94,11 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
-     * @param Attributes|array|null $attributes
-     * @return $this
+     * Add the given attributes
+     *
+     * @param   Attributes|array    $attributes
+     *
+     * @return  $this
      */
     public function addAttributes($attributes)
     {
@@ -93,7 +108,9 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
-     * @return array
+     * Get the default attributes of the element
+     *
+     * @return  array
      */
     public function getDefaultAttributes()
     {
@@ -105,6 +122,13 @@ abstract class BaseHtmlElement extends HtmlDocument
         return $this->tag;
     }
 
+    /**
+     * Set the tag of the element
+     *
+     * @param   string  $tag
+     *
+     * @return  $this
+     */
     public function setTag($tag)
     {
         $this->tag = $tag;
@@ -112,15 +136,16 @@ abstract class BaseHtmlElement extends HtmlDocument
         return $this;
     }
 
+    /**
+     * Render the content of the element to HTML
+     *
+     * @return  string
+     */
     public function renderContent()
     {
         return parent::renderUnwrapped();
     }
 
-    /**
-     * @param array|ValidHtml|string $content
-     * @return $this
-     */
     public function add($content)
     {
         $this->ensureAssembled();
@@ -162,8 +187,11 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
-     * @param HtmlDocument $document
-     * @return $this
+     * Use this element to wrap the given document
+     *
+     * @param   HtmlDocument    $document
+     *
+     * @return  $this
      */
     public function wrap(HtmlDocument $document)
     {
@@ -172,12 +200,27 @@ abstract class BaseHtmlElement extends HtmlDocument
         return $this;
     }
 
+    /**
+     * Get whether the closing tag should be rendered
+     *
+     * @return  bool    True for void elements, false otherwise
+     */
     public function wantsClosingTag()
     {
         // TODO: There is more. SVG and MathML namespaces
         return ! $this->isVoid();
     }
 
+    /**
+     * Get whether the element is void
+     *
+     * The default void detection which checks whether the element's tag is in the list of void elements according to
+     * https://www.w3.org/TR/html5/syntax.html#void-elements.
+     *
+     * If you want to override this behavior, use {@link setVoid()}.
+     *
+     * @return  bool
+     */
     public function isVoid()
     {
         if ($this->isVoid !== null) {
@@ -189,6 +232,16 @@ abstract class BaseHtmlElement extends HtmlDocument
         return isset(self::$voidElements[$tag]);
     }
 
+    /**
+     * Set whether the element is void
+     *
+     * You may use this method to override the default void detection which checks whether the element's tag is in the
+     * list of void elements according to https://www.w3.org/TR/html5/syntax.html#void-elements.
+     *
+     * @param   bool    $isVoid
+     *
+     * @return  $this
+     */
     public function setVoid($void = true)
     {
         $this->isVoid = $void;

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -134,7 +134,7 @@ abstract class BaseHtmlElement extends HtmlDocument
             return sprintf(
                 '<%s%s>%s</%s>',
                 $tag,
-                $this->renderAttributes(),
+                $this->getAttributes()->render(),
                 $content,
                 $tag
             );
@@ -142,20 +142,8 @@ abstract class BaseHtmlElement extends HtmlDocument
             return sprintf(
                 '<%s%s />',
                 $tag,
-                $this->renderAttributes()
+                $this->getAttributes()->render()
             );
-        }
-    }
-
-    /**
-     * @return string
-     */
-    public function renderAttributes()
-    {
-        if ($this->attributes === null && empty($this->defaultAttributes)) {
-            return '';
-        } else {
-            return $this->getAttributes()->render();
         }
     }
 

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -275,7 +275,7 @@ abstract class BaseHtmlElement extends HtmlDocument
      */
     public function setVoid($void = true)
     {
-        $this->isVoid = $void ?: (bool) $void;
+        $this->isVoid = $void === null ?: (bool) $void;
 
         return $this;
     }

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -81,14 +81,14 @@ abstract class BaseHtmlElement extends HtmlDocument
      *
      * If the attribute with the given name already exists, it gets overridden.
      *
-     * @param   string              $key    The name of the attribute
+     * @param   string              $name   The name of the attribute
      * @param   string|bool|array   $value  The value of the attribute
      *
      * @return  $this
      */
-    public function setAttribute($key, $value)
+    public function setAttribute($name, $value)
     {
-        $this->getAttributes()->set($key, $value);
+        $this->getAttributes()->set($name, $value);
 
         return $this;
     }

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -122,29 +122,34 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
-     * @return string
+     * @inheritdoc
+     *
+     * @throws  \RuntimeException   If the element is void but has content
      */
     public function renderUnwrapped()
     {
         $this->ensureAssembled();
-        $tag = $this->getTag();
 
+        $tag = $this->getTag();
+        $attributes = $this->getAttributes()->render();
         $content = $this->renderContent();
-        if (strlen($content) || $this->wantsClosingTag()) {
-            return sprintf(
-                '<%s%s>%s</%s>',
-                $tag,
-                $this->getAttributes()->render(),
-                $content,
-                $tag
-            );
-        } else {
-            return sprintf(
-                '<%s%s />',
-                $tag,
-                $this->getAttributes()->render()
-            );
+
+        if (! $this->wantsClosingTag()) {
+            if (strlen($content)) {
+                // @TODO(el): Should we add a dedicated exception class?
+                throw new \RuntimeException('Void elements must not have content');
+            }
+
+            return sprintf('<%s%s />', $tag, $attributes);
         }
+
+        return sprintf(
+            '<%s%s>%s</%s>',
+            $tag,
+            $attributes,
+            $content,
+            $tag
+        );
     }
 
     /**

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -181,7 +181,7 @@ abstract class BaseHtmlElement extends HtmlDocument
     public function isVoidElement()
     {
         if ($this->isVoid === null) {
-            $this->isVoid = in_array($this->tag, self::$voidElements);
+            $this->isVoid = in_array($this->getTag(), self::$voidElements);
         }
 
         return $this->isVoid;

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -100,16 +100,16 @@ abstract class BaseHtmlElement extends HtmlDocument
         return $this->defaultAttributes;
     }
 
+    public function getTag()
+    {
+        return $this->tag;
+    }
+
     public function setTag($tag)
     {
         $this->tag = $tag;
 
         return $this;
-    }
-
-    public function getTag()
-    {
-        return $this->tag;
     }
 
     public function renderContent()

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -238,13 +238,15 @@ abstract class BaseHtmlElement extends HtmlDocument
      * You may use this method to override the default void detection which checks whether the element's tag is in the
      * list of void elements according to https://www.w3.org/TR/html5/syntax.html#void-elements.
      *
-     * @param   bool    $isVoid
+     * If you specify null, void detection is reset to its default behavior.
+     *
+     * @param   bool|null    $void
      *
      * @return  $this
      */
     public function setVoid($void = true)
     {
-        $this->isVoid = $void;
+        $this->isVoid = $void ?: (bool) $void;
 
         return $this;
     }

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -39,6 +39,11 @@ class Img extends BaseHtmlElement
     }
 }
 
+class Div extends BaseHtmlElement
+{
+    protected $tag = 'div';
+}
+
 class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
 {
     public function testRenderDefaultAttributesAsProperty()
@@ -68,6 +73,21 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
     public function testGetTag()
     {
         $element = new Img();
+
+        $this->assertSame('img', $element->getTag());
+        $this->assertTrue($element->isVoidElement());
+        $this->assertFalse($element->wantsClosingTag());
+    }
+
+    public function testSetTag()
+    {
+        $element = new Div();
+
+        $this->assertSame('div', $element->getTag());
+        $this->assertFalse($element->isVoidElement());
+        $this->assertTrue($element->wantsClosingTag());
+
+        $element->setTag('img');
 
         $this->assertSame('img', $element->getTag());
         $this->assertTrue($element->isVoidElement());

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -31,6 +31,14 @@ class VoidElementWithContent extends BaseHtmlElement
     }
 }
 
+class Img extends BaseHtmlElement
+{
+    public function getTag()
+    {
+        return 'img';
+    }
+}
+
 class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
 {
     public function testRenderDefaultAttributesAsProperty()
@@ -55,5 +63,14 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
     public function testExceptionThrownForVoidElementsWithContent()
     {
         (new VoidElementWithContent())->render();
+    }
+
+    public function testGetTag()
+    {
+        $element = new Img();
+
+        $this->assertSame('img', $element->getTag());
+        $this->assertTrue($element->isVoidElement());
+        $this->assertFalse($element->wantsClosingTag());
     }
 }

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -124,4 +124,23 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
     {
         (new NoTag())->getTag();
     }
+
+    public function testSetVoid()
+    {
+        $element = new Img();
+        $this->assertFalse($element->wantsClosingTag());
+        $this->assertEquals('<img />', $element->render());
+        $element->setVoid();
+        $this->assertFalse($element->wantsClosingTag());
+        $this->assertEquals('<img />', $element->render());
+        $element->setVoid(false);
+        $this->assertTrue($element->wantsClosingTag());
+        $this->assertEquals('<img></img>', $element->render());
+        $element->setVoid(true);
+        $this->assertFalse($element->wantsClosingTag());
+        $this->assertEquals('<img />', $element->render());
+        $element->setVoid(null);
+        $this->assertFalse($element->wantsClosingTag());
+        $this->assertEquals('<img />', $element->render());
+    }
 }

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace ipl\Tests\Html;
+
+use ipl\Html\BaseHtmlElement;
+
+class DefaultAttributesAsProperty extends BaseHtmlElement
+{
+    protected $tag = 'div';
+
+    protected $defaultAttributes = ['class' => 'test'];
+}
+
+class DefaultAttributesAsMethod extends BaseHtmlElement
+{
+    protected $tag = 'div';
+
+    public function getDefaultAttributes()
+    {
+        return ['class' => 'test'];
+    }
+}
+
+class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRenderDefaultAttributesAsProperty()
+    {
+        $this->assertXmlStringEqualsXmlString(
+            '<div class="test"></div>',
+            (new DefaultAttributesAsProperty())->render()
+        );
+    }
+
+    public function testRenderDefaultAttributesAsMethod()
+    {
+        $this->assertXmlStringEqualsXmlString(
+            '<div class="test"></div>',
+            (new DefaultAttributesAsMethod())->render()
+        );
+    }
+}

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -21,6 +21,16 @@ class DefaultAttributesAsMethod extends BaseHtmlElement
     }
 }
 
+class VoidElementWithContent extends BaseHtmlElement
+{
+    protected $tag = 'img';
+
+    protected function assemble()
+    {
+        $this->add('content');
+    }
+}
+
 class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
 {
     public function testRenderDefaultAttributesAsProperty()
@@ -37,5 +47,13 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
             '<div class="test"></div>',
             (new DefaultAttributesAsMethod())->render()
         );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testExceptionThrownForVoidElementsWithContent()
+    {
+        (new VoidElementWithContent())->render();
     }
 }

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -34,7 +34,7 @@ class VoidElementWithContent extends BaseHtmlElement
 
 class Img extends BaseHtmlElement
 {
-    public function getTag()
+    protected function tag()
     {
         return 'img';
     }
@@ -43,6 +43,11 @@ class Img extends BaseHtmlElement
 class Div extends BaseHtmlElement
 {
     protected $tag = 'div';
+}
+
+class NoTag extends BaseHtmlElement
+{
+
 }
 
 class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
@@ -94,5 +99,29 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('img', $element->getTag());
         $this->assertTrue($element->isVoid());
         $this->assertFalse($element->wantsClosingTag());
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testAssertTagInRender()
+    {
+        (new NoTag())->render();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testAssertTagInIsVoid()
+    {
+        (new NoTag())->isVoid();
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testAssertTagInGetTag()
+    {
+        (new NoTag())->getTag();
     }
 }

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -75,7 +75,7 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
         $element = new Img();
 
         $this->assertSame('img', $element->getTag());
-        $this->assertTrue($element->isVoidElement());
+        $this->assertTrue($element->isVoid());
         $this->assertFalse($element->wantsClosingTag());
     }
 
@@ -84,13 +84,13 @@ class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
         $element = new Div();
 
         $this->assertSame('div', $element->getTag());
-        $this->assertFalse($element->isVoidElement());
+        $this->assertFalse($element->isVoid());
         $this->assertTrue($element->wantsClosingTag());
 
         $element->setTag('img');
 
         $this->assertSame('img', $element->getTag());
-        $this->assertTrue($element->isVoidElement());
+        $this->assertTrue($element->isVoid());
         $this->assertFalse($element->wantsClosingTag());
     }
 }

--- a/tests/php/BaseHtmlElementTest.php
+++ b/tests/php/BaseHtmlElementTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use ipl\Html\BaseHtmlElement;
 
+// @codingStandardsIgnoreStart
 class DefaultAttributesAsProperty extends BaseHtmlElement
 {
     protected $tag = 'div';
@@ -46,6 +47,7 @@ class Div extends BaseHtmlElement
 
 class BaseHtmlElementTest extends \PHPUnit_Framework_TestCase
 {
+    // @codingStandardsIgnoreEnd
     public function testRenderDefaultAttributesAsProperty()
     {
         $this->assertXmlStringEqualsXmlString(


### PR DESCRIPTION
Hi Tom,

I fixed some bugs in `BaseHtmlElement` and added PHPDoc where necessary. I added test cases and commit descriptions which should explain the changes. But these are the highlights:

* `render()` did not respect a possible `getDefaultAttributes()` override
* Elements which did not specify a tag were rendered as `<>$content`. It's now just `$content`
* It was allowed to create void elements with content. The content was silently ignored upon rendering. We now throw an Exception here
* `getTag()` overrides were not respected in some places
* `in_array()` is replaced with `isset()` for void detection and the cache has been removed. `setTag()` did not invalidate the cache which may have lead to false results when calling `isVoid()` or `wantsClosingTag()`
* `setVoid()` explicitly supports `null`. Was working before but now it is documented

Cheers,
Eric