### PR TITLE
Fix callback inconsistency

### DIFF
--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -216,6 +216,13 @@ class Attributes
         return $this;
     }
 
+    public function setCallback($name, $getter, $setter = null)
+    {
+        $this->registerAttributeCallback($name, $getter, $setter);
+
+        return $this;
+    }
+
     /**
      * Callback must return an instance of Attribute
      *

--- a/tests/php/AttributesTest.php
+++ b/tests/php/AttributesTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace ipl\Tests\Html;
+
+use Exception;
+use RuntimeException;
+use UnexpectedValueException;
+use ipl\Html\Attribute;
+use ipl\Html\Attributes;
+
+class AttributesTest extends TestCase
+{
+    public function testGetterCallbackInGet()
+    {
+        $callback = function () {
+            return new Attribute('callback', 'value from callback');
+        };
+
+        $attributes = (new Attributes())
+            ->setCallback('callback', $callback);
+
+        $this->assertSame($attributes->get('callback')->getValue(), 'value from callback');
+    }
+
+    public function testSetterCallbackInSet()
+    {
+        $element = new ElementWithCallbackAttributes();
+
+        $attributes = $element->getAttributes();
+
+        $attributes->set('name', 'name from test');
+
+        $this->assertSame('name from test', $attributes->get('name')->getValue());
+        $this->assertSame('name from test', $element->getName());
+    }
+
+    public function testSetterCallbackInAdd()
+    {
+        $element = new ElementWithCallbackAttributes();
+
+        $attributes = $element->getAttributes();
+
+        $attributes->add('name', 'name from test');
+
+        $this->assertSame('name from test', $attributes->get('name')->getValue());
+        $this->assertSame('name from test', $element->getName());
+    }
+
+    public function testSetterCallbackIsProxied()
+    {
+        $element = new ElementWithCallbackAttributes();
+
+        $attributes = $element->getAttributes();
+
+        $attributes->get('name')->setValue('name from test');
+
+        $this->assertSame('name from test', $attributes->get('name')->getValue());
+        $this->assertSame('name from test', $element->getName());
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testCantOverrideCallbacks()
+    {
+        $callback = function () {
+            return new Attribute('callback', 'value from callback');
+        };
+
+        $attributes = (new Attributes())
+            ->setCallback('callback', $callback);
+
+        $attributes->set('callback', 'overridden');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testGetterCallbackRuntimeException()
+    {
+        $callback = function () {
+            throw new Exception();
+        };
+
+        $attributes = (new Attributes())
+            ->setCallback('callback', $callback);
+
+        $attributes->get('callback');
+    }
+
+    /**
+     * @expectedException UnexpectedValueException
+     */
+    public function testGetterCallbackValueException()
+    {
+        $callback = function () {
+            return [];
+        };
+
+        $attributes = (new Attributes())
+            ->setCallback('callback', $callback);
+
+        $attributes->get('callback');
+    }
+}

--- a/tests/php/ElementWithCallbackAttributes.php
+++ b/tests/php/ElementWithCallbackAttributes.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ipl\Tests\Html;
+
+use ipl\Html\BaseHtmlElement;
+
+class ElementWithCallbackAttributes extends BaseHtmlElement
+{
+    protected $name;
+
+    public function __construct()
+    {
+        $this->registerCallbacks();
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function setName($name)
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    protected function registerCallbacks()
+    {
+        $this->getAttributes()->setCallback('name', [$this, 'getName'], [$this, 'setName']);
+    }
+}


### PR DESCRIPTION
Attribute callbacks should work with all methods in the Attributes class. Right now they are only evaluated in `render()`. Further, there is no error handling if a callback fails. This PR attempts to fix the following issues:

1. `Attributes::get()` must return an `Attribute` instance which is produced from the callback's result. If the callback fails, a `RuntimeException` is raised. If the callback's result type is invalid, a `UnexpectedValueException` is raised. The exception stuff applies to `render()` as well.

2. Setter callbacks must be proxied in the `Attribute` instance returned from a callback in `Attributes::get()`.

3. `Attributes::set()` and `Attributes::add()` must use registered callbacks. If the attribute already exists in `add()` an exception must be raised.

4. If there is no setter callback, an Exception must be raised when trying to override the respective attribute.

5. When trying to add callbacks to an attribute which already exists, an exception is raised.

6. `Attributes::get()` must raise an exception if there is only a setter callback specified.

For the moment I just added failing tests for the uses cases above. @Thomas-Gelf Please evaluate whether this makes sense. I'll start fixing this then.