### PR TITLE
PHPDoc and small fixes/enhancements for the Attribute and Attributes classes

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -21,6 +21,9 @@ class Attribute
     /** @var string|array|bool|null */
     protected $value;
 
+    /** @var string Glue string to join elements if the attribute's value is an array */
+    protected $glue = ' ';
+
     /**
      * Create a new HTML attribute from the given name and value
      *
@@ -211,7 +214,7 @@ class Attribute
      */
     public function renderValue()
     {
-        return static::escapeValue($this->value);
+        return static::escapeValue($this->value, $this->glue);
     }
 
     /**
@@ -225,14 +228,23 @@ class Attribute
     }
 
     /**
-     * @param $value
-     * @return string
+     * Escape the value of an attribute
+     *
+     * If the value is an array, returns the string representation
+     * of all array elements joined with the specified glue string.
+     *
+     * Escaping takes place using {@link Html::encode()}.
+     *
+     * @param   string|array    $value
+     * @param   string          $glue   Glue string to join elements if value is an array
+     *
+     * @return  string
      */
-    public static function escapeValue($value)
+    public static function escapeValue($value, $glue = ' ')
     {
         // TODO: escape differently
         if (is_array($value)) {
-            return Html::escape(implode(' ', $value));
+            return Html::escape(implode($glue, $value));
         } else {
             return Html::escape((string) $value);
         }

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -79,7 +79,9 @@ class Attribute
     }
 
     /**
-     * @return string
+     * Get the value of the attribute
+     *
+     * @return  string|bool|array|null
      */
     public function getValue()
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -142,7 +142,9 @@ class Attribute
     }
 
     /**
-     * @return bool
+     * Test and return true if the attribute is boolean, false otherwise
+     *
+     * @return  bool
      */
     public function isBoolean()
     {
@@ -150,7 +152,11 @@ class Attribute
     }
 
     /**
-     * @return bool
+     * Test and return true if the attribute is empty, false otherwise
+     *
+     * Null and the empty array will be considered empty.
+     *
+     * @return  bool
      */
     public function isEmpty()
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -150,6 +150,14 @@ class Attribute
     }
 
     /**
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return null === $this->value || $this->value === [];
+    }
+
+    /**
      * Render the attribute to HTML
      *
      * If the value of the attribute is of type boolean, it will be rendered as
@@ -198,14 +206,6 @@ class Attribute
     public function renderValue()
     {
         return static::escapeValue($this->value);
-    }
-
-    /**
-     * @return bool
-     */
-    public function isEmpty()
-    {
-        return null === $this->value || $this->value === [];
     }
 
     /**

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -35,10 +35,14 @@ class Attribute
     }
 
     /**
-     * @param $name
-     * @param $value
-     * @return static
-     * @throws InvalidArgumentException
+     * Create a new HTML attribute from the given name and value
+     *
+     * @param   string                  $name   The name of the attribute
+     * @param   string|bool|array|null  $value  The value of the attribute
+     *
+     * @return  static
+     *
+     * @throws  InvalidArgumentException        If the name of the attribute contains special characters
      */
     public static function create($name, $value)
     {
@@ -46,9 +50,15 @@ class Attribute
     }
 
     /**
-     * @param $name
-     * @return static
-     * @throws InvalidArgumentException
+     * Create a new empty HTML attribute from the given name
+     *
+     * The value of the attribute will be null after construction.
+     *
+     * @param   string                  $name   The name of the attribute
+     *
+     * @return  static
+     *
+     * @throws  InvalidArgumentException        If the name of the attribute contains special characters
      */
     public static function createEmpty($name)
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -22,11 +22,12 @@ class Attribute
     protected $value;
 
     /**
-     * Attribute constructor.
+     * Create a new HTML attribute from the given name and value
      *
-     * @param $name
-     * @param $value
-     * @throws InvalidArgumentException
+     * @param   string                  $name   The name of the attribute
+     * @param   string|bool|array|null  $value  The value of the attribute
+     *
+     * @throws  InvalidArgumentException        If the name of the attribute contains special characters
      */
     public function __construct($name, $value = null)
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -130,7 +130,18 @@ class Attribute
     }
 
     /**
-     * @return string
+     * Render the attribute to HTML
+     *
+     * If the value of the attribute is of type boolean, it will be rendered as
+     * {@link http://www.w3.org/TR/html5/infrastructure.html#boolean-attributes boolean attribute}.
+     * Note that in this case if the value of the attribute is false, the empty string will be returned.
+     *
+     * If the value of the attribute is null or an empty array,
+     * the empty string will be returned as well.
+     *
+     * Escaping of the attribute's value takes place automatically using {@link Html::escape()}.
+     *
+     * @return  string
      */
     public function render()
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -202,7 +202,9 @@ class Attribute
     }
 
     /**
-     * @return string
+     * Render the name of the attribute to HTML
+     *
+     * @return  string
      */
     public function renderName()
     {
@@ -210,7 +212,9 @@ class Attribute
     }
 
     /**
-     * @return string
+     * Render the value of the attribute to HTML
+     *
+     * @return  string
      */
     public function renderValue()
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -264,7 +264,6 @@ class Attribute
      */
     public static function escapeName($name)
     {
-        // TODO: escape
         return (string) $name;
     }
 

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -195,7 +195,7 @@ class Attribute
      */
     public function isEmpty()
     {
-        return null === $this->value || $this->value === [];
+        return $this->value === null || $this->value === [];
     }
 
     /**

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -145,6 +145,38 @@ class Attribute
     }
 
     /**
+     * Remove the given value from the attribute
+     *
+     * The current value is set to null if it matches the value to remove
+     * or is in the array of values to remove.
+     *
+     * If the current value is an array, all elements are removed which
+     * match the value(s) to remove.
+     *
+     * Does nothing if there is no such value to remove.
+     *
+     * @param   string|array $value      The value(s) to remove
+     *
+     * @return  $this
+     */
+    public function removeValue($value)
+    {
+        if (! is_array($value)) {
+            $value = [$value];
+        }
+
+        $current = $this->getValue();
+
+        if (is_array($current)) {
+            $this->setValue(array_diff($current, $value));
+        } elseif (in_array($current, $value, true)) {
+            $this->setValue(null);
+        }
+
+        return $this;
+    }
+
+    /**
      * Test and return true if the attribute is boolean, false otherwise
      *
      * @return  bool

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -89,8 +89,11 @@ class Attribute
     }
 
     /**
-     * @param mixed $value
-     * @return $this
+     * Set the value of the attribute
+     *
+     * @param   string|bool|array|null  $value
+     *
+     * @return  $this
      */
     public function setValue($value)
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -222,8 +222,13 @@ class Attribute
     }
 
     /**
-     * @param $name
-     * @return string
+     * Escape the name of an attribute
+     *
+     * Makes sure that the name of an attribute really is a string.
+     *
+     * @param   string  $name
+     *
+     * @return  string
      */
     public static function escapeName($name)
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -46,6 +46,16 @@ class Attribute
     }
 
     /**
+     * @param $name
+     * @return static
+     * @throws InvalidArgumentException
+     */
+    public static function createEmpty($name)
+    {
+        return new static($name, null);
+    }
+
+    /**
      * Get the name of the attribute
      *
      * @return  string
@@ -186,16 +196,6 @@ class Attribute
     public function isEmpty()
     {
         return null === $this->value || $this->value === [];
-    }
-
-    /**
-     * @param $name
-     * @return static
-     * @throws InvalidArgumentException
-     */
-    public static function createEmpty($name)
-    {
-        return new static($name, null);
     }
 
     /**

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -12,7 +12,6 @@ use InvalidArgumentException;
  *
  * Usually attributes are not instantiated directly, but created through an HTML
  * element's exposed methods.
- *
  */
 class Attribute
 {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -53,11 +53,15 @@ class Attribute
     }
 
     /**
-     * @param $name
-     * @return $this
-     * @throws InvalidArgumentException
+     * Set the name of the attribute
+     *
+     * @param   string  $name
+     *
+     * @return  $this
+     *
+     * @throws  InvalidArgumentException    If the name contains special characters
      */
-    public function setName($name)
+    protected function setName($name)
     {
         if (! preg_match('/^[a-z][a-z0-9:-]*$/i', $name)) {
             throw new InvalidArgumentException(sprintf(
@@ -65,6 +69,7 @@ class Attribute
                 $name
             ));
         }
+
         $this->name = $name;
 
         return $this;

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -46,7 +46,9 @@ class Attribute
     }
 
     /**
-     * @return string
+     * Get the name of the attribute
+     *
+     * @return  string
      */
     public function getName()
     {

--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -134,8 +134,16 @@ class Attribute
      */
     public function render()
     {
-        if ($this->isBoolean() && $this->value) {
-            return $this->renderName();
+        if ($this->isEmpty()) {
+            return '';
+        }
+
+        if ($this->isBoolean()) {
+            if ($this->value) {
+                return $this->renderName();
+            }
+
+            return '';
         } else {
             return sprintf(
                 '%s="%s"',

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -171,19 +171,28 @@ class Attributes
     }
 
     /**
-     * @param $name
-     * @return Attribute|false
+     * Remove the attribute with the given name or remove the given value from the attribute
+     *
+     * @param   string                  $name   The name of the attribute
+     * @param   null|string|array       $value  The value to remove if specified
+     *
+     * @return  Attribute|false
      */
-    public function remove($name)
+    public function remove($name, $value = null)
     {
-        if ($this->has($name)) {
-            $attribute = $this->attributes[$name];
-            unset($this->attributes[$name]);
-
-            return $attribute;
-        } else {
+        if (! $this->has($name)) {
             return false;
         }
+
+        $attribute = $this->attributes[$name];
+
+        if ($value === null) {
+            unset($this->attributes[$name]);
+        } else {
+            $attribute->removeValue($value);
+        }
+
+        return $attribute;
     }
 
     /**

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -93,6 +93,46 @@ class Attributes
     }
 
     /**
+     * Set the given attribute(s)
+     *
+     * If the attribute with the given name already exists, it gets overridden.
+     *
+     * @param   string|array|Attribute|self $attribute  The attribute(s) to add
+     * @param   string|bool|array           $value      The value of the attribute
+     *
+     * @return  $this
+     *
+     * @throws  InvalidArgumentException    If the attribute name contains special characters
+     */
+    public function set($attribute, $value = null)
+    {
+        if ($attribute instanceof static) {
+            foreach ($attribute as $a) {
+                $this->setAttribute($a);
+            }
+
+            return $this;
+        } elseif ($attribute instanceof Attribute) {
+            return $this->setAttribute($attribute);
+        } elseif (is_array($attribute)) {
+            foreach ($attribute as $name => $value) {
+                $this->set($name, $value);
+            }
+
+            return $this;
+        } else {
+            if (array_key_exists($attribute, $this->setterCallbacks)) {
+                $callback = $this->setterCallbacks[$attribute];
+                $callback($value);
+
+                return $this;
+            } else {
+                return $this->setAttribute(new Attribute($attribute, $value));
+            }
+        }
+    }
+
+    /**
      * Add the given attribute(s)
      *
      * If an attribute with the same name already exists, the attribute's value will be added to the current value of
@@ -128,40 +168,6 @@ class Attributes
         }
 
         return $this;
-    }
-
-    /**
-     * @param Attribute|array|string $attribute
-     * @param string|array $value
-     * @return $this
-     * @throws InvalidArgumentException
-     */
-    public function set($attribute, $value = null)
-    {
-        if ($attribute instanceof static) {
-            foreach ($attribute as $a) {
-                $this->setAttribute($a);
-            }
-
-            return $this;
-        } elseif ($attribute instanceof Attribute) {
-            return $this->setAttribute($attribute);
-        } elseif (is_array($attribute)) {
-            foreach ($attribute as $name => $value) {
-                $this->set($name, $value);
-            }
-
-            return $this;
-        } else {
-            if (array_key_exists($attribute, $this->setterCallbacks)) {
-                $callback = $this->setterCallbacks[$attribute];
-                $callback($value);
-
-                return $this;
-            } else {
-                return $this->setAttribute(new Attribute($attribute, $value));
-            }
-        }
     }
 
     /**

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -76,7 +76,7 @@ class Attributes
     /**
      * Get the attribute with the given name
      *
-     * If the attribute does not yet exist, it is automatically created.
+     * If the attribute does not yet exist, it is automatically created and registered to this Attributes instance.
      *
      * @param   string  $name
      *
@@ -86,11 +86,11 @@ class Attributes
      */
     public function get($name)
     {
-        if ($this->has($name)) {
-            return $this->attributes[$name];
-        } else {
-            return Attribute::createEmpty($name);
+        if (! $this->has($name)) {
+            $this->attributes[$name] = Attribute::createEmpty($name);
         }
+
+        return $this->attributes[$name];
     }
 
     /**

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -223,7 +223,8 @@ class Attributes
     public function addAttribute(Attribute $attribute)
     {
         $name = $attribute->getName();
-        if (array_key_exists($name, $this->attributes)) {
+
+        if ($this->has($name)) {
             $this->attributes[$name]->addValue($attribute->getValue());
         } else {
             $this->attributes[$name] = $attribute;

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -73,6 +73,26 @@ class Attributes
     }
 
     /**
+     * Get the attribute with the given name
+     *
+     * If the attribute does not yet exist, it is automatically created.
+     *
+     * @param   string  $name
+     *
+     * @return  Attribute
+     *
+     * @throws  InvalidArgumentException    If the attribute does not yet exist and its name contains special characters
+     */
+    public function get($name)
+    {
+        if ($this->has($name)) {
+            return $this->attributes[$name];
+        } else {
+            return Attribute::createEmpty($name);
+        }
+    }
+
+    /**
      * @param Attribute|string $attribute
      * @param string|array $value
      * @return $this
@@ -134,20 +154,6 @@ class Attributes
             } else {
                 return $this->setAttribute(new Attribute($attribute, $value));
             }
-        }
-    }
-
-    /**
-     * @param $name
-     * @return Attribute
-     * @throws InvalidArgumentException
-     */
-    public function get($name)
-    {
-        if ($this->has($name)) {
-            return $this->attributes[$name];
-        } else {
-            return Attribute::createEmpty($name);
         }
     }
 

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -315,9 +315,20 @@ class Attributes
     }
 
     /**
-     * @param Attributes|array|null $attributes
-     * @return Attributes
-     * @throws InvalidArgumentException
+     * Ensure that the given attributes of mixed type are converted to an instance of attributes
+     *
+     * The conversion procedure is as follows:
+     *
+     * If the given attributes is already an instance of Attributes, returns the very same element.
+     * If the attributes are given as an array of attribute name-value pairs, they are used to
+     * construct and return a new Attributes instance.
+     * If the attributes are null, an empty new instance of Attributes is returned.
+     *
+     * @param   array|static|null   $attributes
+     *
+     * @return  static
+     *
+     * @throws  InvalidArgumentException    In case the given attributes are of an unsupported type
      */
     public static function wantAttributes($attributes)
     {

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Html;
 
+use ipl\Stdlib;
 use InvalidArgumentException;
 
 class Attributes
@@ -332,23 +333,21 @@ class Attributes
      */
     public static function wantAttributes($attributes)
     {
-        if ($attributes instanceof Attributes) {
+        if ($attributes instanceof self) {
             return $attributes;
-        } else {
-            $self = new static();
-            if (is_array($attributes)) {
-                foreach ($attributes as $k => $v) {
-                    $self->add($k, $v);
-                }
-
-                return $self;
-            } elseif ($attributes !== null) {
-                throw new InvalidArgumentException(sprintf(
-                    'Attributes, Array or Null expected, got %s',
-                    Error::getPhpTypeName($attributes)
-                ));
-            }
-            return $self;
         }
+
+        if (is_array($attributes)) {
+            return new static($attributes);
+        }
+
+        if ($attributes === null) {
+            return new static();
+        }
+
+        throw new InvalidArgumentException(sprintf(
+            'Attributes instance, array or null expected. Got %s instead.',
+            Stdlib\get_php_type($attributes)
+        ));
     }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -287,8 +287,18 @@ class Attributes
     }
 
     /**
-     * @return string
-     * @throws InvalidArgumentException
+     * Render attributes to HTML
+     *
+     * If the value of an attribute is of type boolean, it will be rendered as
+     * {@link http://www.w3.org/TR/html5/infrastructure.html#boolean-attributes boolean attribute}.
+     *
+     * If the value of an attribute is null, it will be skipped.
+     *
+     * HTML-escaping of the attributes' values takes place automatically using {@link Html::escape()}.
+     *
+     * @return  string
+     *
+     * @throws  InvalidArgumentException    If the result of a callback is invalid
      */
     public function render()
     {

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -107,30 +107,39 @@ class Attributes
      */
     public function set($attribute, $value = null)
     {
-        if ($attribute instanceof static) {
+        if ($attribute instanceof self) {
             foreach ($attribute as $a) {
                 $this->setAttribute($a);
             }
 
             return $this;
-        } elseif ($attribute instanceof Attribute) {
-            return $this->setAttribute($attribute);
-        } elseif (is_array($attribute)) {
+        }
+
+        if ($attribute instanceof Attribute) {
+            $this->setAttribute($attribute);
+
+            return $this;
+        }
+
+        if (is_array($attribute)) {
             foreach ($attribute as $name => $value) {
                 $this->set($name, $value);
             }
 
             return $this;
-        } else {
-            if (array_key_exists($attribute, $this->setterCallbacks)) {
-                $callback = $this->setterCallbacks[$attribute];
-                $callback($value);
-
-                return $this;
-            } else {
-                return $this->setAttribute(new Attribute($attribute, $value));
-            }
         }
+
+        if (array_key_exists($attribute, $this->setterCallbacks)) {
+            $callback = $this->setterCallbacks[$attribute];
+
+            $callback($value);
+
+            return $this;
+        }
+
+        $this->attributes[$attribute] = Attribute::create($attribute, $value);
+
+        return $this;
     }
 
     /**

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -93,10 +93,17 @@ class Attributes
     }
 
     /**
-     * @param Attribute|string $attribute
-     * @param string|array $value
-     * @return $this
-     * @throws InvalidArgumentException
+     * Add the given attribute(s)
+     *
+     * If an attribute with the same name already exists, the attribute's value will be added to the current value of
+     * the attribute.
+     *
+     * @param   string|array|Attribute|self $attribute  The attribute(s) to add
+     * @param   string|bool|array           $value      The value of the attribute
+     *
+     * @return  $this
+     *
+     * @throws  InvalidArgumentException    If the attribute does not yet exist and its name contains special characters
      */
     public function add($attribute, $value = null)
     {

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -61,6 +61,18 @@ class Attributes
     }
 
     /**
+     * Return true if the attribute with the given name exists, false otherwise
+     *
+     * @param   string  $name
+     *
+     * @return  bool
+     */
+    public function has($name)
+    {
+        return array_key_exists($name, $this->attributes);
+    }
+
+    /**
      * @param Attribute|string $attribute
      * @param string|array $value
      * @return $this
@@ -153,15 +165,6 @@ class Attributes
         } else {
             return false;
         }
-    }
-
-    /**
-     * @param $name
-     * @return bool
-     */
-    public function has($name)
-    {
-        return array_key_exists($name, $this->attributes);
     }
 
     /**

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -311,7 +311,7 @@ class Attributes
                 }
             } elseif (is_string($attribute)) {
                 $parts[] = Attribute::create($name, $attribute)->render();
-            } elseif (null === $attribute) {
+            } elseif ($attribute === null) {
                 continue;
             } else {
                 throw new InvalidArgumentException(

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -333,7 +333,7 @@ class Attributes
             return '';
         }
 
-        $separator = ' ' . $this->prefix;
+        $separator = ' ' . $this->getPrefix();
 
         return $separator . implode($separator, $parts);
     }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -205,8 +205,8 @@ class Attributes
      */
     public function setAttribute(Attribute $attribute)
     {
-        $name = $attribute->getName();
-        $this->attributes[$name] = $attribute;
+        $this->attributes[$attribute->getName()] = $attribute;
+
         return $this;
     }
 

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -196,8 +196,28 @@ class Attributes
     }
 
     /**
-     * @param Attribute $attribute
-     * @return $this
+     * Set the specified attribute
+     *
+     * @param   Attribute   $attribute
+     *
+     * @return  $this
+     */
+    public function setAttribute(Attribute $attribute)
+    {
+        $name = $attribute->getName();
+        $this->attributes[$name] = $attribute;
+        return $this;
+    }
+
+    /**
+     * Add the specified attribute
+     *
+     * If an attribute with the same name already exists, the given attribute's value
+     * will be added to the current value of the attribute.
+     *
+     * @param   Attribute $attribute
+     *
+     * @return  $this
      */
     public function addAttribute(Attribute $attribute)
     {
@@ -208,17 +228,6 @@ class Attributes
             $this->attributes[$name] = $attribute;
         }
 
-        return $this;
-    }
-
-    /**
-     * @param Attribute $attribute
-     * @return $this
-     */
-    public function setAttribute(Attribute $attribute)
-    {
-        $name = $attribute->getName();
-        $this->attributes[$name] = $attribute;
         return $this;
     }
 

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -51,33 +51,6 @@ class Attributes
     }
 
     /**
-     * @param Attributes|array|null $attributes
-     * @return Attributes
-     * @throws InvalidArgumentException
-     */
-    public static function wantAttributes($attributes)
-    {
-        if ($attributes instanceof Attributes) {
-            return $attributes;
-        } else {
-            $self = new static();
-            if (is_array($attributes)) {
-                foreach ($attributes as $k => $v) {
-                    $self->add($k, $v);
-                }
-
-                return $self;
-            } elseif ($attributes !== null) {
-                throw new InvalidArgumentException(sprintf(
-                    'Attributes, Array or Null expected, got %s',
-                    Error::getPhpTypeName($attributes)
-                ));
-            }
-            return $self;
-        }
-    }
-
-    /**
      * @return Attribute[]
      */
     public function getAttributes()
@@ -297,5 +270,32 @@ class Attributes
         $this->prefix = $prefix;
 
         return $this;
+    }
+
+    /**
+     * @param Attributes|array|null $attributes
+     * @return Attributes
+     * @throws InvalidArgumentException
+     */
+    public static function wantAttributes($attributes)
+    {
+        if ($attributes instanceof Attributes) {
+            return $attributes;
+        } else {
+            $self = new static();
+            if (is_array($attributes)) {
+                foreach ($attributes as $k => $v) {
+                    $self->add($k, $v);
+                }
+
+                return $self;
+            } elseif ($attributes !== null) {
+                throw new InvalidArgumentException(sprintf(
+                    'Attributes, Array or Null expected, got %s',
+                    Error::getPhpTypeName($attributes)
+                ));
+            }
+            return $self;
+        }
     }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -157,24 +157,40 @@ class Attributes
      */
     public function add($attribute, $value = null)
     {
-        // TODO: do not allow Attribute and Attributes
-        if ($attribute instanceof Attributes) {
-            foreach ($attribute->getAttributes() as $a) {
-                $this->add($a);
+        if ($attribute instanceof self) {
+            foreach ($attribute as $attr) {
+                $this->add($attr);
             }
-        } elseif ($attribute instanceof Attribute) {
-            $this->addAttribute($attribute);
-        } elseif (is_array($attribute)) {
+
+            return $this;
+        }
+
+        if (is_array($attribute)) {
             foreach ($attribute as $name => $value) {
                 $this->add($name, $value);
             }
+
+            return $this;
+        }
+
+        if ($attribute instanceof Attribute) {
+            $this->addAttribute($attribute);
+
+            return $this;
+        }
+
+        if (array_key_exists($attribute, $this->setterCallbacks)) {
+            $callback = $this->setterCallbacks[$attribute];
+
+            $callback($value);
+
+            return $this;
+        }
+
+        if (! array_key_exists($attribute, $this->attributes)) {
+            $this->attributes[$attribute] = Attribute::create($attribute, $value);
         } else {
-            if (array_key_exists($attribute, $this->setterCallbacks)) {
-                $callback = $this->setterCallbacks[$attribute];
-                $callback($value);
-            } else {
-                $this->addAttribute(Attribute::create($attribute, $value));
-            }
+            $this->attributes[$attribute]->addValue($value);
         }
 
         return $this;

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -320,7 +320,7 @@ class Attributes
      *
      * If the value of an attribute is null, it will be skipped.
      *
-     * HTML-escaping of the attributes' values takes place automatically using {@link Html::escape()}.
+     * HTML-escaping of the attributes' values takes place automatically using {@link Attribute::escapeValue()}.
      *
      * @return  string
      *

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -263,6 +263,30 @@ class Attributes
     }
 
     /**
+     * Get the attributes name prefix
+     *
+     * @return  string|null
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * Set the attributes name prefix
+     *
+     * @param   string  $prefix
+     *
+     * @return  $this
+     */
+    public function setPrefix($prefix)
+    {
+        $this->prefix = $prefix;
+
+        return $this;
+    }
+
+    /**
      * @return string
      * @throws InvalidArgumentException
      */
@@ -302,17 +326,6 @@ class Attributes
         $separator = ' ' . $this->prefix;
 
         return $separator . implode($separator, $parts);
-    }
-
-    /**
-     * @param string $prefix
-     * @return $this
-     */
-    public function setPrefix($prefix)
-    {
-        $this->prefix = $prefix;
-
-        return $this;
     }
 
     /**

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -51,7 +51,9 @@ class Attributes
     }
 
     /**
-     * @return Attribute[]
+     * Get the collection of attributes as array
+     *
+     * @return  Attribute[]
      */
     public function getAttributes()
     {

--- a/tests/php/AttributeTest.php
+++ b/tests/php/AttributeTest.php
@@ -124,6 +124,54 @@ class AttributeTest extends TestCase
         $this->assertSame('', (new Attribute('name', []))->render());
     }
 
+    public function testRemoveValue()
+    {
+        $this->assertSame(
+            null,
+            (new Attribute('name', 'value'))->removeValue('value')->getValue()
+        );
+    }
+
+    public function testRemoveValueNoop()
+    {
+        $this->assertSame(
+            'value',
+            (new Attribute('name', 'value'))->removeValue('noop')->getValue()
+        );
+    }
+
+    public function testRemoveValueWithArrayAndArrayValue()
+    {
+        $this->assertSame(
+            ['foo'],
+            (new Attribute('class', ['foo', 'bar']))->removeValue(['bar'])->getValue()
+        );
+    }
+
+    public function testRemoveValueNoopWithArrayAndArrayValue()
+    {
+        $this->assertSame(
+            ['foo', 'bar'],
+            (new Attribute('class', ['foo', 'bar']))->removeValue(['baz'])->getValue()
+        );
+    }
+
+    public function testRemoveValueWithArrayAndScalarValue()
+    {
+        $this->assertSame(
+            null,
+            (new Attribute('class', 'foo'))->removeValue(['foo'])->getValue()
+        );
+    }
+
+    public function testRemoveValueNoopWithArrayAndScalarValue()
+    {
+        $this->assertSame(
+            'foo',
+            (new Attribute('class', 'foo'))->removeValue(['bar'])->getValue()
+        );
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/php/AttributeTest.php
+++ b/tests/php/AttributeTest.php
@@ -109,6 +109,21 @@ class AttributeTest extends TestCase
         );
     }
 
+    public function testRenderFalse()
+    {
+        $this->assertSame('', (new Attribute('name', false))->render());
+    }
+
+    public function testRenderNull()
+    {
+        $this->assertSame('', (new Attribute('name', null))->render());
+    }
+
+    public function testRenderEmptyArray()
+    {
+        $this->assertSame('', (new Attribute('name', []))->render());
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/php/AttributeTest.php
+++ b/tests/php/AttributeTest.php
@@ -77,14 +77,6 @@ class AttributeTest extends TestCase
         );
     }
 
-    public function testSpecialCharactersAreEscaped()
-    {
-        $this->assertEquals(
-            '“‘&gt;&quot;&amp;&lt;’”',
-            Attribute::create('x', '“‘>"&<’”')->renderValue()
-        );
-    }
-
     public function testUmlautCharactersArePreserved()
     {
         $this->assertEquals(
@@ -104,8 +96,40 @@ class AttributeTest extends TestCase
     public function testComplexAttributeIsCorrectlyEscaped()
     {
         $this->assertEquals(
-            'data-some-thing="&quot;sweet&quot; &amp; - $ ist &lt;süß&gt;"',
+            'data-some-thing="&quot;sweet&quot; & - $ ist <süß>"',
             Attribute::create('data-some-thing', '"sweet" & - $ ist <süß>')->render()
+        );
+    }
+
+    public function testEscapeValueEscapesDoubleQuotes()
+    {
+        $this->assertSame(
+            '&quot;value&quot;',
+            Attribute::escapeValue('"value"')
+        );
+    }
+
+    public function testEscapeValueEscapesAmbiguousAmpersands()
+    {
+        $this->assertSame(
+            'value&amp;1234;',
+            Attribute::escapeValue('value&1234;')
+        );
+    }
+
+    public function testEscapeValueDoesNotDoubleQuote()
+    {
+        $this->assertSame(
+            '&quot;value&quot;',
+            Attribute::escapeValue('&quot;value&quot;')
+        );
+    }
+
+    public function testEscapeValueTreatsSpecialCharacters()
+    {
+        $this->assertEquals(
+            '“‘>&quot;&>’”',
+            Attribute::create('x', '“‘>"&>’”')->renderValue()
         );
     }
 

--- a/tests/php/AttributesTest.php
+++ b/tests/php/AttributesTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ipl\Tests\Html;
+
+use ipl\Html\Attributes;
+
+class AttributesTest extends TestCase
+{
+    public function testGetWithNonexistentAttribute()
+    {
+        $attributes = new Attributes();
+
+        $attributes
+            ->get('name')
+            ->setValue('value');
+
+        $this->assertSame(
+            'value',
+            $attributes->get('name')->getValue()
+        );
+    }
+}


### PR DESCRIPTION
Most of this PR introduces PHPDoc and some method reordering. Notable fixes are:

* Removed `setName()`. Runtime changes must be forbidden for name. I considered to make this protected but then it is also subject to runtime changes in subclasses.
* `Attribute::render()` renders empty and boolean false attrs as the empty string
* `Attribute::escapeValue()` now expects a glue string
* New method `Attribute::removeValue()`

If you want, I'll squash the PHPDoc related commits once we're finished with the review.