### PR TITLE
Support multiple submit buttons

### DIFF
--- a/src/Contract/FormSubmitElement.php
+++ b/src/Contract/FormSubmitElement.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ipl\Html\Contract;
+
+interface FormSubmitElement
+{
+    /**
+     * Get whether the element has been pressed
+     *
+     * @return bool
+     */
+    public function hasBeenPressed();
+}

--- a/src/Form.php
+++ b/src/Form.php
@@ -28,6 +28,9 @@ class Form extends BaseHtmlElement
     /** @var FormSubmitElement */
     protected $submitButton;
 
+    /** @var FormSubmitElement[] */
+    protected $submitElements = [];
+
     /** @var ServerRequestInterface */
     private $request;
 
@@ -235,9 +238,27 @@ class Form extends BaseHtmlElement
         return $this;
     }
 
+    /**
+     * Get the submit element used to send the form
+     *
+     * @return FormSubmitElement|null
+     */
+    public function getPressedSubmitElement()
+    {
+        foreach ($this->submitElements as $submitElement) {
+            if ($submitElement->hasBeenPressed()) {
+                return $submitElement;
+            }
+        }
+
+        return null;
+    }
+
     protected function onElementRegistered(BaseFormElement $element)
     {
         if ($element instanceof FormSubmitElement) {
+            $this->submitElements[$element->getName()] = $element;
+
             if (! $this->hasSubmitButton()) {
                 $this->setSubmitButton($element);
             }

--- a/src/Form.php
+++ b/src/Form.php
@@ -2,8 +2,9 @@
 
 namespace ipl\Html;
 
+use ipl\Html\Contract\FormSubmitElement;
+use ipl\Html\FormElement\BaseFormElement;
 use ipl\Html\FormElement\FormElementContainer;
-use ipl\Html\FormElement\SubmitElement;
 use ipl\Stdlib\MessageContainer;
 use Exception;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,7 +25,7 @@ class Form extends BaseHtmlElement
 
     protected $method;
 
-    /** @var SubmitElement */
+    /** @var FormSubmitElement */
     protected $submitButton;
 
     /** @var ServerRequestInterface */
@@ -180,7 +181,7 @@ class Form extends BaseHtmlElement
         return $this->submitButton !== null;
     }
 
-    public function setSubmitButton(SubmitElement $element)
+    public function setSubmitButton(FormSubmitElement $element)
     {
         $this->submitButton = $element;
 
@@ -232,5 +233,14 @@ class Form extends BaseHtmlElement
         $this->getAttributes()->set('action', $action);
 
         return $this;
+    }
+
+    protected function onElementRegistered(BaseFormElement $element)
+    {
+        if ($element instanceof FormSubmitElement) {
+            if (! $this->hasSubmitButton()) {
+                $this->setSubmitButton($element);
+            }
+        }
     }
 }

--- a/src/FormElement/FormElementContainer.php
+++ b/src/FormElement/FormElementContainer.php
@@ -211,6 +211,10 @@ trait FormElementContainer
 
         $this->elements[$name] = $type;
 
+        if (array_key_exists($name, $this->populatedValues)) {
+            $type->setValue($this->populatedValues[$name]);
+        }
+
         $this->onElementRegistered($name, $type);
         $this->emit(Form::ON_ELEMENT_REGISTERED, [$name, $type]);
 
@@ -219,14 +223,6 @@ trait FormElementContainer
 
     public function onElementRegistered($name, BaseFormElement $element)
     {
-        // TODO: hasSubmitButton is not here
-        if ($element instanceof SubmitElement && ! $this->hasSubmitButton()) {
-            $this->setSubmitButton($element);
-        }
-
-        if (\array_key_exists($name, $this->populatedValues)) {
-            $element->setValue($this->populatedValues[$name]);
-        }
     }
 
     /**

--- a/src/FormElement/FormElementContainer.php
+++ b/src/FormElement/FormElementContainer.php
@@ -221,10 +221,6 @@ trait FormElementContainer
         return $this;
     }
 
-    public function onElementRegistered($name, BaseFormElement $element)
-    {
-    }
-
     /**
      * @param string $type
      * @param string $name
@@ -316,5 +312,9 @@ trait FormElementContainer
             Form::ON_REQUEST,
             Form::ON_ELEMENT_REGISTERED,
         ]);
+    }
+
+    protected function onElementRegistered($name, BaseFormElement $element)
+    {
     }
 }

--- a/src/FormElement/FormElementContainer.php
+++ b/src/FormElement/FormElementContainer.php
@@ -215,7 +215,7 @@ trait FormElementContainer
             $type->setValue($this->populatedValues[$name]);
         }
 
-        $this->onElementRegistered($name, $type);
+        $this->onElementRegistered($type);
         $this->emit(Form::ON_ELEMENT_REGISTERED, [$name, $type]);
 
         return $this;
@@ -314,7 +314,7 @@ trait FormElementContainer
         ]);
     }
 
-    protected function onElementRegistered($name, BaseFormElement $element)
+    protected function onElementRegistered(BaseFormElement $element)
     {
     }
 }

--- a/src/FormElement/FormElementContainer.php
+++ b/src/FormElement/FormElementContainer.php
@@ -216,7 +216,7 @@ trait FormElementContainer
         }
 
         $this->onElementRegistered($type);
-        $this->emit(Form::ON_ELEMENT_REGISTERED, [$name, $type]);
+        $this->emit(Form::ON_ELEMENT_REGISTERED, [$type]);
 
         return $this;
     }

--- a/src/FormElement/SubmitElement.php
+++ b/src/FormElement/SubmitElement.php
@@ -3,8 +3,9 @@
 namespace ipl\Html\FormElement;
 
 use ipl\Html\Attribute;
+use ipl\Html\Contract\FormSubmitElement;
 
-class SubmitElement extends InputElement
+class SubmitElement extends InputElement implements FormSubmitElement
 {
     protected $type = 'submit';
 
@@ -37,9 +38,6 @@ class SubmitElement extends InputElement
         return new Attribute('value', $this->getButtonLabel());
     }
 
-    /**
-     * @return bool
-     */
     public function hasBeenPressed()
     {
         return $this->getButtonLabel() === $this->getValue();


### PR DESCRIPTION
This PR introduces new methods to support multiple submit buttons.
It does not interfere with the idea that our forms have one primary submit button.

The primary submit button is handled via `has/get/setSubmittButton()` and `hasBeenSubmitted()`.
Other pressed submit buttons are retrieved via `getPressedSubmitElement()`.

The question here is how we handle form redirects:

For the primary submit button we call `hasBeenSubmitted() and isValid()`.

For other submit buttons we have to do something like the following:
`getPressedSubmitElement() && (! getPressedSubmitElement()->getAttributes()->get('formnovalidate') || isValid())`.

@Thomas-Gelf I'd like to provide this as method in our forms. Maybe something like `isComplete()`?

We also talked about onsuccess callbacks and the method onSend. I'd like to address this in a separate PR.