### PR TITLE
[WIP] Fix supported validator specs

### DIFF
--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -239,7 +239,7 @@ abstract class BaseFormElement extends BaseHtmlElement
      * @param $options
      * @return ValidatorInterface
      */
-    public function createValidator($name, $options)
+    public function createValidator($name, $options = null)
     {
         $class = 'ipl\\Validator\\' . ucfirst($name) . 'Validator';
         if (class_exists($class)) {

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -246,8 +246,7 @@ abstract class BaseFormElement extends BaseHtmlElement
             return new $class($options);
         } else {
             throw new InvalidArgumentException(
-                'Unable to create Validator: %s',
-                $name
+                "Can't create validator $name: Class $class not found"
             );
         }
     }

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -203,9 +203,31 @@ abstract class BaseFormElement extends BaseHtmlElement
     public function setValidators(array $validators)
     {
         $this->validators = [];
-        foreach ($validators as $validator => $options) {
+        foreach ($validators as $name => $validator) {
             if (! $validator instanceof ValidatorInterface) {
-                $validator = $this->createValidator($validator, $options);
+                if (is_int($name)) {
+                    if (! is_array($validator)) {
+                        throw new InvalidArgumentException(
+                            'Invalid validator specification: Neither a validator instance nor an array provided'
+                        );
+                    }
+
+                    if (! isset($validator['name'])) {
+                        throw new InvalidArgumentException(
+                            'Invalid validator array specification: Key "name" is missing'
+                        );
+                    }
+
+                    $name = $validator['name'];
+
+                    if (isset($validator['options'])) {
+                        $validator = $validator['options'];
+                    } else {
+                        $validator = null;
+                    }
+                }
+
+                $validator = $this->createValidator($name, $validator);
             }
 
             $this->validators[] = $validator;

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -206,23 +206,22 @@ abstract class BaseFormElement extends BaseHtmlElement
         foreach ($validators as $name => $validator) {
             if (! $validator instanceof ValidatorInterface) {
                 if (is_int($name)) {
-                    if (! is_array($validator)) {
-                        throw new InvalidArgumentException(
-                            'Invalid validator specification: Neither a validator instance nor an array provided'
-                        );
-                    }
+                    if (is_array($validator)) {
+                        if (! isset($validator['name'])) {
+                            throw new InvalidArgumentException(
+                                'Invalid validator array specification: Key "name" is missing'
+                            );
+                        }
 
-                    if (! isset($validator['name'])) {
-                        throw new InvalidArgumentException(
-                            'Invalid validator array specification: Key "name" is missing'
-                        );
-                    }
+                        $name = $validator['name'];
 
-                    $name = $validator['name'];
-
-                    if (isset($validator['options'])) {
-                        $validator = $validator['options'];
+                        if (isset($validator['options'])) {
+                            $validator = $validator['options'];
+                        } else {
+                            $validator = null;
+                        }
                     } else {
+                        $name = $validator;
                         $validator = null;
                     }
                 }

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -242,13 +242,14 @@ abstract class BaseFormElement extends BaseHtmlElement
     public function createValidator($name, $options = null)
     {
         $class = 'ipl\\Validator\\' . ucfirst($name) . 'Validator';
-        if (class_exists($class)) {
-            return new $class($options);
-        } else {
+
+        if (! class_exists($class)) {
             throw new InvalidArgumentException(
                 "Can't create validator $name: Class $class not found"
             );
         }
+
+        return new $class($options);
     }
 
     public function hasValue()

--- a/tests/php/FormElement/ValidatorSpecTest.php
+++ b/tests/php/FormElement/ValidatorSpecTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace ipl\Tests\Html\FormElement;
+
+use ipl\Tests\Html\TestCase;
+use ipl\Tests\Html\TestDummy\TestFormElement;
+use ipl\Validator\TestValidator;
+
+class ValidatorSpecTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        require_once dirname(__DIR__) . '/TestDummy/TestValidator.php';
+    }
+
+    public function testNameToOptionsSpec()
+    {
+        $options = [
+            'key' => 'value'
+        ];
+
+        $spec = [
+            'test' => $options
+        ];
+
+        $validators = $this->populateValidators($spec);
+
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
+        $this->assertSame($options, $validators[0]->getOptions());
+    }
+
+    public function testArraySpec()
+    {
+        $options = [
+            'key' => 'value'
+        ];
+
+        $spec = [
+            [
+                'name'    => 'test',
+                'options' => $options
+            ]
+        ];
+
+        $validators = $this->populateValidators($spec);
+
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
+        $this->assertSame($options, $validators[0]->getOptions());
+    }
+
+    public function testArraySpecWithoutOptions()
+    {
+        $spec = [
+            [
+                'name' => 'test'
+            ]
+        ];
+
+        $validators = $this->populateValidators($spec);
+
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
+        $this->assertNull($validators[0]->getOptions());
+    }
+
+    public function testWithValidatorInstance()
+    {
+        $spec = [
+            new TestValidator()
+        ];
+
+        $validators = $this->populateValidators($spec);
+
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
+    }
+
+    public function testWithAllSpecsMixed()
+    {
+        $spec = [
+            'test' => [],
+            [
+                'name' => 'test'
+            ],
+            new TestValidator()
+        ];
+
+        $validators = $this->populateValidators($spec);
+
+        $this->assertCount(3, $validators);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[1]);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[2]);
+    }
+
+    /**
+     * @expectedException   \InvalidArgumentException
+     */
+    public function testArraySpecExceptionIfNameIsMissing()
+    {
+        $spec = [
+            [
+            ]
+        ];
+
+        $this->populateValidators($spec);
+    }
+
+    /**
+     * @expectedException   \InvalidArgumentException
+     */
+    public function testNameToOptionsSpecExceptionIfClassDoesNotExist()
+    {
+        $spec = [
+            'doesnotexist' => null
+        ];
+
+        $this->populateValidators($spec);
+    }
+
+    /**
+     * @expectedException   \InvalidArgumentException
+     */
+    public function testNameToOptionsSpecExceptionIfNameIsNotTheKeyAndThereforeOptionsNotAnArray()
+    {
+        $spec = [
+            'test'
+        ];
+
+        $this->populateValidators($spec);
+    }
+
+    /**
+     * @param   array   $spec
+     *
+     * @return  \ipl\Stdlib\Contracts\ValidatorInterface[]
+     */
+    protected function populateValidators(array $spec)
+    {
+        $element = new TestFormElement('test');
+
+        $element->setValidators($spec);
+
+        return $element->getValidators();
+    }
+}

--- a/tests/php/FormElement/ValidatorSpecTest.php
+++ b/tests/php/FormElement/ValidatorSpecTest.php
@@ -65,6 +65,20 @@ class ValidatorSpecTest extends TestCase
         $this->assertNull($validators[0]->getOptions());
     }
 
+    public function testWithNameOnly()
+    {
+        $spec = [
+            'test'
+        ];
+
+        $validators = $this->populateValidators($spec);
+
+        $validators = $this->populateValidators($spec);
+
+        $this->assertCount(1, $validators);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
+    }
+
     public function testWithValidatorInstance()
     {
         $spec = [
@@ -84,15 +98,17 @@ class ValidatorSpecTest extends TestCase
             [
                 'name' => 'test'
             ],
+            'test',
             new TestValidator()
         ];
 
         $validators = $this->populateValidators($spec);
 
-        $this->assertCount(3, $validators);
+        $this->assertCount(4, $validators);
         $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[0]);
         $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[1]);
         $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[2]);
+        $this->assertInstanceOf('\\ipl\\Validator\\TestValidator', $validators[3]);
     }
 
     /**
@@ -115,18 +131,6 @@ class ValidatorSpecTest extends TestCase
     {
         $spec = [
             'doesnotexist' => null
-        ];
-
-        $this->populateValidators($spec);
-    }
-
-    /**
-     * @expectedException   \InvalidArgumentException
-     */
-    public function testNameToOptionsSpecExceptionIfNameIsNotTheKeyAndThereforeOptionsNotAnArray()
-    {
-        $spec = [
-            'test'
         ];
 
         $this->populateValidators($spec);

--- a/tests/php/TestDummy/TestFormElement.php
+++ b/tests/php/TestDummy/TestFormElement.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ipl\Tests\Html\TestDummy;
+
+use ipl\Html\FormElement\BaseFormElement;
+
+class TestFormElement extends BaseFormElement
+{
+}

--- a/tests/php/TestDummy/TestValidator.php
+++ b/tests/php/TestDummy/TestValidator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ipl\Validator;
+
+use ipl\Stdlib\Contracts\ValidatorInterface;
+
+class TestValidator implements ValidatorInterface
+{
+    protected $options;
+
+    public function __construct($options = null)
+    {
+        $this->options = $options;
+    }
+
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    public function isValid($value)
+    {
+    }
+
+    public function getMessages()
+    {
+    }
+}


### PR DESCRIPTION
With this PR we support the following methods for setting validators:

```php
// Name to options
$validators = [
    'strlen' => [
        'min' => 8,
         'max' => 32
    ]
];

// Array
$validators = [
    [
        'name' => strlen,
        'options' => ...
    ],
    [
        'name' => 'email'
    ]
];

// Simple
$validators = ['email', 'iban'];

// Instance of ValidatorInterface
$validators = [new EmailValidator(), ...];
```

Before, we just supported the name to options spec.

@Thomas-Gelf I'd like to move the validator factory functionality from `setValidators()` to a dedicated class/function, e.g. `Validators` or `ValidatorChain` with `wantValidators`. There we may add something like Zend's break on failure and registering/loading of custom validators via our stdlib. What do you think? `getValidators()` in the form element would then return an instance of this class.