### PR TITLE
HtmlDocument::addFrom()

### DIFF
--- a/doc/10-Quickstart.md
+++ b/doc/10-Quickstart.md
@@ -237,3 +237,21 @@ Still, we do not consider this code being very readable. In case you ever used
 ```html
 Hi <strong>there</strong>, are you ok?
 ```
+
+### Passing Elements
+
+Say you've now written your own wonderful widget. It's even so wonderful you want to re-use some of its components
+in another widget? You're in luck, there's a handy shortcut with which you can easily pass elements from one widget
+to another.
+
+Let's assume our menu example is a proper widget now and add its entries while transforming them to dashboard tiles:
+
+```php
+<?= Html::tag('div', ['class' => 'dashboard'])->addFrom(new Menu(), function ($li) {
+    return $li->setTag('div');
+}); ?>
+```
+
+```html
+<div class="dashboard"><div>First point</div><div>Second point</div><div>Third point</div></div>
+```

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -324,8 +324,6 @@ class HtmlDocument implements Countable, ValidHtml
     }
 
     /**
-     * @deprecated
-     *
      * return ValidHtml[]
      */
     public function getContent()

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -43,6 +43,24 @@ class HtmlDocument implements Countable, ValidHtml
     }
 
     /**
+     * @param HtmlDocument $from
+     * @param callable     $callback
+     *
+     * @return $this
+     */
+    public function addFrom(HtmlDocument $from, $callback = null)
+    {
+        $from->ensureAssembled();
+
+        $isCallable = is_callable($callback);
+        foreach ($from->getContent() as $item) {
+            $this->add($isCallable ? $callback($item) : $item);
+        }
+
+        return $this;
+    }
+
+    /**
      * @param BaseHtmlElement $wrapper
      * @return $this
      */

--- a/tests/HtmlDocumentTest.php
+++ b/tests/HtmlDocumentTest.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Html;
 
+use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html as h;
 use ipl\Html\HtmlDocument;
 use ipl\Tests\Html\TestDummy\AddsWrapperDuringAssemble;
@@ -120,6 +121,44 @@ class HtmlDocumentTest extends TestCase
         $this->assertEquals(
             '<b>three</b>',
             $a->render()
+        );
+    }
+
+    public function testAddFromCorrectlyPassesElements()
+    {
+        $ul = h::tag('ul');
+        $ul->add(h::tag('li', ['style' => 'margin:0'], 'one'));
+        $ul->add(h::tag('li', 'two'));
+        $ul->add(h::tag('li', 'three'));
+
+        $ol = h::tag('ol');
+        $ol->addFrom($ul);
+
+        $this->assertRendersHtml(
+            '<ol><li style="margin:0">one</li><li>two</li><li>three</li></ol>',
+            $ol
+        );
+    }
+
+    public function testAddFromCorrectlyPassesElementsWithCallback()
+    {
+        $ul = h::tag('ul');
+        $ul->add(h::tag('li', ['id' => '1'], 'one'));
+        $ul->add(h::tag('li', ['id' => '2'], 'two'));
+        $ul->add(h::tag('li', ['id' => '3'], 'three'));
+
+        $div = h::tag('div');
+        $div->addFrom($ul, function (BaseHtmlElement $item) {
+            if ($item->getAttributes()->get('id')->getValue() !== '2') {
+                $item->setTag('p');
+                $item->getAttributes()->remove('id');
+                return $item;
+            }
+        });
+
+        $this->assertRendersHtml(
+            '<div><p>one</p><p>three</p></div>',
+            $div
         );
     }
 }


### PR DESCRIPTION
Example usage:

```php
$columns->addFrom($hostStats, function (BaseHtmlElement $item) {
    $item->getAttributes()->add(['class' => 'col']);
    $item->setTag('div');
    return $item;
});
```