### PR TITLE
Fix empty claim though content is added in assemble

### DIFF
--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -209,6 +209,8 @@ class HtmlDocument implements Countable, Wrappable
      */
     public function isEmpty()
     {
+        $this->ensureAssembled();
+
         return empty($this->content);
     }
 

--- a/tests/HtmlDocumentTest.php
+++ b/tests/HtmlDocumentTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Html;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html as h;
 use ipl\Html\HtmlDocument;
+use ipl\Tests\Html\TestDummy\AddsContentDuringAssemble;
 use ipl\Tests\Html\TestDummy\AddsWrapperDuringAssemble;
 use ipl\Tests\Html\TestDummy\IterableElement;
 use ipl\Tests\Html\TestDummy\ObjectThatCanBeCastedToString;
@@ -204,5 +205,10 @@ class HtmlDocumentTest extends TestCase
             ->prepend(new IterableElement());
 
         $this->assertHtml('<b>foo</b><b>bar</b><b>baz</b>', $html);
+    }
+
+    public function testIsEmptyRespectsContentAddedInAssemble()
+    {
+        $this->assertFalse((new AddsContentDuringAssemble())->isEmpty());
     }
 }

--- a/tests/TestDummy/AddsContentDuringAssemble.php
+++ b/tests/TestDummy/AddsContentDuringAssemble.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ipl\Tests\Html\TestDummy;
+
+use ipl\Html\HtmlDocument;
+
+class AddsContentDuringAssemble extends HtmlDocument
+{
+    protected function assemble()
+    {
+        $this->add('content');
+    }
+}


### PR DESCRIPTION
Before, isEmpty() would always return false even if there is content to
be added in assemble(). Now ensureAssembled() is called before the empty
check.