### PR TITLE
New form event to handle autosubmits

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -20,6 +20,7 @@ class Form extends BaseHtmlElement
     const ON_ERROR = 'error';
     const ON_REQUEST = 'request';
     const ON_SUCCESS = 'success';
+    const ON_SENT = 'sent';
 
     /** @var string Form submission URL */
     protected $action;
@@ -220,6 +221,7 @@ class Form extends BaseHtmlElement
         if (! $this->hasSubmitButton() || $this->getSubmitButton()->hasBeenPressed()) {
             if ($this->isValid()) {
                 try {
+                    $this->emit(Form::ON_SENT, [$this]);
                     $this->onSuccess();
                     $this->emitOnce(Form::ON_SUCCESS, [$this]);
                 } catch (Exception $e) {
@@ -232,6 +234,7 @@ class Form extends BaseHtmlElement
             }
         } else {
             $this->validatePartial();
+            $this->emit(Form::ON_SENT, [$this]);
         }
 
         return $this;

--- a/src/Form.php
+++ b/src/Form.php
@@ -39,6 +39,9 @@ class Form extends BaseHtmlElement
     /** @var ServerRequestInterface The server request being processed */
     private $request;
 
+    /** @var string */
+    private $redirectUrl;
+
     protected $tag = 'form';
 
     /**
@@ -151,6 +154,30 @@ class Form extends BaseHtmlElement
     {
         $this->request = $request;
         $this->emit(Form::ON_REQUEST, [$request]);
+
+        return $this;
+    }
+
+    /**
+     * Get the url to redirect to on success
+     *
+     * @return string
+     */
+    public function getRedirectUrl()
+    {
+        return $this->redirectUrl;
+    }
+
+    /**
+     * Set the url to redirect to on success
+     *
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function setRedirectUrl($url)
+    {
+        $this->redirectUrl = $url;
 
         return $this;
     }

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -431,6 +431,7 @@ trait FormElements
     {
         return in_array($event, [
             Form::ON_SUCCESS,
+            Form::ON_SENT,
             Form::ON_ERROR,
             Form::ON_REQUEST,
             Form::ON_ELEMENT_REGISTERED,


### PR DESCRIPTION
This adds the event `ON_SENT` to class `Form` which is emitted once a form has been partially validated.

This allows to register handling for forms which is run in any case once it's submitted.
Though, actions to run upon user submits are still possible in `ON_SUCCESS` events.

The added property for the redirection url is a complement to this, as it allows to define the url in `ON_SENT` and then use it either in `ON_SUCCESS` or custom code that runs later checking for `Form::hasBeenSent()`.