### PR TITLE
Use `Form::hasBeenSent()` in `Form::handleRequest()`

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -191,16 +191,14 @@ class Form extends BaseHtmlElement
     {
         $this->setRequest($request);
 
-        $method = $request->getMethod();
-
-        if ($method !== $this->getMethod()) {
+        if (! $this->hasBeenSent()) {
             // Always assemble
             $this->ensureAssembled();
 
             return $this;
         }
 
-        switch ($method) {
+        switch ($request->getMethod()) {
             case 'POST':
                 $params = $request->getParsedBody();
 


### PR DESCRIPTION
Changes `ipl\Html\Form::handleRequest()` to use `ipl\Html\Form::hasBeenSent()` instead of an explicit HTTP method check.

This allows concrete form classes to override said method and apply their own extensions: https://github.com/Icinga/ipl-web/pull/20

fixes #45