### PR TITLE
More strict interfaces

### DIFF
--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -112,6 +112,22 @@ class Attributes implements ArrayAccess, IteratorAggregate
     }
 
     /**
+     * Merge the given attributes
+     *
+     * @param Attributes $attributes
+     *
+     * @return $this
+     */
+    public function merge(Attributes $attributes)
+    {
+        foreach ($attributes as $attribute) {
+            $this->addAttribute($attribute);
+        }
+
+        return $this;
+    }
+
+    /**
      * Return true if the attribute with the given name exists, false otherwise
      *
      * @param string $name

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -310,21 +310,6 @@ abstract class BaseHtmlElement extends HtmlDocument
         return $this;
     }
 
-    public function setContent($content)
-    {
-        // setContent() calls $this->add() which would assemble the element and that does not make any sense here
-        // Plus, this allows subclasses of BaseHtmlElement to add content before assemble() --
-        // in the constructor for example
-
-        $this->hasBeenAssembled = true;
-
-        parent::setContent($content);
-
-        $this->hasBeenAssembled = false;
-
-        return $this;
-    }
-
     /**
      * @inheritdoc
      *

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -301,11 +301,11 @@ abstract class BaseHtmlElement extends HtmlDocument
     {
     }
 
-    public function add($content)
+    public function addHtml(ValidHtml ...$content)
     {
         $this->ensureAssembled();
 
-        parent::add($content);
+        parent::addHtml(...$content);
 
         return $this;
     }

--- a/src/Error.php
+++ b/src/Error.php
@@ -41,7 +41,7 @@ abstract class Error
 
         $result = static::renderErrorMessage($msg);
         if (static::showTraces()) {
-            $result->add(Html::tag('pre', $error->getTraceAsString()));
+            $result->addHtml(Html::tag('pre', $error->getTraceAsString()));
         }
 
         return $result;
@@ -101,7 +101,7 @@ abstract class Error
     protected static function renderErrorMessage($message)
     {
         $output = new HtmlDocument();
-        $output->add(
+        $output->addHtml(
             Html::tag('div', ['class' => 'exception'], [
                 Html::tag('h1', [
                     Html::tag('i', ['class' => 'icon-bug']),

--- a/src/Form.php
+++ b/src/Form.php
@@ -346,7 +346,7 @@ class Form extends BaseHtmlElement
                 $message = $message->getMessage();
             }
 
-            $errors->add(Html::tag('li', $message));
+            $errors->addHtml(Html::tag('li', $message));
         }
 
         if (! $errors->isEmpty()) {

--- a/src/Form.php
+++ b/src/Form.php
@@ -350,7 +350,7 @@ class Form extends BaseHtmlElement
         }
 
         if (! $errors->isEmpty()) {
-            $this->prepend($errors);
+            $this->prependHtml($errors);
         }
     }
 

--- a/src/FormDecorator/DdDtDecorator.php
+++ b/src/FormDecorator/DdDtDecorator.php
@@ -5,6 +5,7 @@ namespace ipl\Html\FormDecorator;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\FormElement\BaseFormElement;
 use ipl\Html\Html;
+use ipl\Html\ValidHtml;
 
 class DdDtDecorator extends BaseHtmlElement implements DecoratorInterface
 {
@@ -92,11 +93,11 @@ class DdDtDecorator extends BaseHtmlElement implements DecoratorInterface
         return null;
     }
 
-    public function add($content)
+    public function addHtml(ValidHtml ...$content)
     {
         // TODO: is this required?
-        if ($content !== $this->wrappedElement) {
-            parent::add($content);
+        if (! in_array($this->wrappedElement, $content, true)) {
+            parent::addHtml(...$content);
         }
 
         return $this;

--- a/src/FormDecorator/DdDtDecorator.php
+++ b/src/FormDecorator/DdDtDecorator.php
@@ -105,7 +105,7 @@ class DdDtDecorator extends BaseHtmlElement implements DecoratorInterface
 
     protected function assemble()
     {
-        $this->add([$this->dt(), $this->dd()]);
+        $this->addHtml($this->dt(), $this->dd());
         $this->ready = true;
     }
 

--- a/src/FormDecorator/DivDecorator.php
+++ b/src/FormDecorator/DivDecorator.php
@@ -10,6 +10,7 @@ use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\FormElement\HiddenElement;
 use ipl\Html\Html;
 use ipl\Html\HtmlElement;
+use ipl\Html\Text;
 
 /**
  * Form element decorator based on div elements
@@ -84,10 +85,12 @@ class DivDecorator extends BaseHtmlElement implements FormElementDecorator
 
     protected function assembleErrors()
     {
-        $errors = new HtmlElement('ul', ['class' => static::ERROR_CLASS]);
+        $errors = new HtmlElement('ul', Attributes::create(['class' => static::ERROR_CLASS]));
 
         foreach ($this->formElement->getMessages() as $message) {
-            $errors->add(new HtmlElement('li', ['class' => static::ERROR_CLASS], $message));
+            $errors->addHtml(
+                new HtmlElement('li', Attributes::create(['class' => static::ERROR_CLASS]), Text::create($message))
+            );
         }
 
         if (! $errors->isEmpty()) {
@@ -119,7 +122,7 @@ class DivDecorator extends BaseHtmlElement implements FormElementDecorator
             $this->getAttributes()->add('class', static::ERROR_HINT_CLASS);
         }
 
-        $this->add(array_filter([
+        $this->addHtml(...Html::wantHtmlList([
             $this->assembleLabel(),
             $this->assembleElement(),
             $this->assembleDescription(),

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -124,7 +124,7 @@ trait FormElements
         $this
             ->registerElement($element) // registerElement() must be called first because of the name check
             ->decorate($element)
-            ->add($element);
+            ->addHtml($element);
 
         return $this;
     }

--- a/src/FormElement/SelectElement.php
+++ b/src/FormElement/SelectElement.php
@@ -111,7 +111,7 @@ class SelectElement extends BaseFormElement
         if (is_array($label)) {
             $grp = Html::tag('optgroup', ['label' => $value]);
             foreach ($label as $option => $val) {
-                $grp->add($this->makeOption($option, $val));
+                $grp->addHtml($this->makeOption($option, $val));
             }
 
             return $grp;
@@ -134,8 +134,6 @@ class SelectElement extends BaseFormElement
 
     protected function assemble()
     {
-        foreach ($this->optionContent as $value => $option) {
-            $this->add($option);
-        }
+        $this->addHtml(...array_values($this->optionContent));
     }
 }

--- a/src/Html.php
+++ b/src/Html.php
@@ -153,6 +153,32 @@ abstract class Html
     }
 
     /**
+     * Accept any input and return it as list of ValidHtml
+     *
+     * @param mixed $content
+     *
+     * @return ValidHtml[]
+     */
+    public static function wantHtmlList($content)
+    {
+        $list = [];
+
+        if ($content === null) {
+            return $list;
+        } elseif (! is_iterable($content)) {
+            $list[] = static::wantHtml($content);
+        } elseif ($content instanceof ValidHtml) {
+            $list[] = $content;
+        } else {
+            foreach ($content as $part) {
+                $list = array_merge($list, static::wantHtmlList($part));
+            }
+        }
+
+        return $list;
+    }
+
+    /**
      * Get whether the given variable be rendered as a string
      *
      * @param mixed $any

--- a/src/Html.php
+++ b/src/Html.php
@@ -26,17 +26,32 @@ abstract class Html
      */
     public static function tag($name, $attributes = null, $content = null)
     {
-        if ($attributes instanceof ValidHtml || is_scalar($attributes)) {
-            $content = $attributes;
+        if ($content !== null) {
+            // If not null, it's html content, no question
+            $content = static::wantHtmlList($content);
+        } elseif ($attributes instanceof ValidHtml || is_scalar($attributes)) {
+            // Otherwise $attributes may be $content, but only if definitely **NOT** attributes
+            $content = static::wantHtmlList($attributes);
             $attributes = null;
-        } elseif (is_iterable($attributes)) {
-            if (is_int(iterable_key_first($attributes))) {
-                $content = $attributes;
+        }
+
+        if ($attributes !== null) {
+            if (! is_iterable($attributes) || ! is_int(iterable_key_first($attributes))) {
+                // Not an array (e.g. instance of Attributes) or an associative array
+                $attributes = Attributes::wantAttributes($attributes);
+            } elseif (is_iterable($attributes)) {
+                // $attributes may still be $content, in case of a sequenced array
+                if ($content !== null) {
+                    // But not if there's already $content
+                    throw new InvalidArgumentException('Value of argument $attributes are no attributes');
+                }
+
+                $content = static::wantHtmlList($attributes);
                 $attributes = null;
             }
         }
 
-        return new HtmlElement($name, $attributes, $content);
+        return new HtmlElement($name, $attributes, ...($content ?: []));
     }
 
     /**

--- a/src/Html.php
+++ b/src/Html.php
@@ -119,7 +119,7 @@ abstract class Html
         $result = new HtmlDocument();
         foreach ($list as $name => $value) {
             if (is_string($wrapper)) {
-                $result->add(Html::tag($wrapper, $value));
+                $result->addHtml(Html::tag($wrapper, $value));
             } elseif (is_callable($wrapper)) {
                 $result->add($wrapper($name, $value));
             } else {
@@ -154,7 +154,7 @@ abstract class Html
             $html = new HtmlDocument();
             foreach ($any as $el) {
                 if ($el !== null) {
-                    $html->add(static::wantHtml($el));
+                    $html->addHtml(static::wantHtml($el));
                 }
             }
 

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -83,7 +83,7 @@ class HtmlDocument implements Countable, Wrappable
     public function setContent($content)
     {
         $this->content = [];
-        $this->add($content);
+        $this->setHtmlContent(...Html::wantHtmlList($content));
 
         return $this;
     }

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -238,17 +238,7 @@ class HtmlDocument implements Countable, Wrappable
      */
     public function prepend($content)
     {
-        if (is_iterable($content) && ! $content instanceof ValidHtml) {
-            foreach (array_reverse(is_array($content) ? $content : iterator_to_array($content)) as $c) {
-                $this->prepend($c);
-            }
-        } elseif ($content !== null) {
-            $pos = 0;
-            $html = Html::wantHtml($content);
-            array_unshift($this->content, $html);
-            $this->incrementIndexKeys();
-            $this->addObjectPosition($html, $pos);
-        }
+        $this->prependHtml(...Html::wantHtmlList($content));
 
         return $this;
     }

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -89,6 +89,23 @@ class HtmlDocument implements Countable, Wrappable
     }
 
     /**
+     * Set content
+     *
+     * @param ValidHtml ...$content
+     *
+     * @return $this
+     */
+    public function setHtmlContent(ValidHtml ...$content)
+    {
+        $this->content = [];
+        foreach ($content as $element) {
+            $this->addIndexedContent($element);
+        }
+
+        return $this;
+    }
+
+    /**
      * Get the content separator
      *
      * @return string

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -156,6 +156,22 @@ class HtmlDocument implements Countable, Wrappable
     }
 
     /**
+     * Add content
+     *
+     * @param ValidHtml ...$content
+     *
+     * @return $this
+     */
+    public function addHtml(ValidHtml ...$content)
+    {
+        foreach ($content as $element) {
+            $this->addIndexedContent($element);
+        }
+
+        return $this;
+    }
+
+    /**
      * Add content from the given document
      *
      * @param HtmlDocument $from

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -161,13 +161,7 @@ class HtmlDocument implements Countable, Wrappable
      */
     public function add($content)
     {
-        if (is_iterable($content) && ! $content instanceof ValidHtml) {
-            foreach ($content as $c) {
-                $this->add($c);
-            }
-        } elseif ($content !== null) {
-            $this->addIndexedContent(Html::wantHtml($content));
-        }
+        $this->addHtml(...Html::wantHtmlList($content));
 
         return $this;
     }

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -254,6 +254,24 @@ class HtmlDocument implements Countable, Wrappable
     }
 
     /**
+     * Prepend content
+     *
+     * @param ValidHtml ...$content
+     *
+     * @return $this
+     */
+    public function prependHtml(ValidHtml ...$content)
+    {
+        foreach (array_reverse($content) as $html) {
+            array_unshift($this->content, $html);
+            $this->incrementIndexKeys();
+            $this->addObjectPosition($html, 0);
+        }
+
+        return $this;
+    }
+
+    /**
      * Remove content
      *
      * @param ValidHtml $html

--- a/src/HtmlElement.php
+++ b/src/HtmlElement.php
@@ -12,34 +12,32 @@ class HtmlElement extends BaseHtmlElement
     /**
      * Create a new HTML element from the given tag, attributes and content
      *
-     * @param string                 $tag        The tag for the element
-     * @param Attributes|array       $attributes The HTML attributes for the element
-     * @param ValidHtml|string|array $content    The content of the element
+     * @param string     $tag        The tag for the element
+     * @param Attributes $attributes The HTML attributes for the element
+     * @param ValidHtml  ...$content The content of the element
      */
-    public function __construct($tag, $attributes = null, $content = null)
+    public function __construct($tag, Attributes $attributes = null, ValidHtml ...$content)
     {
         $this->tag = $tag;
 
         if ($attributes !== null) {
-            $this->getAttributes()->add($attributes);
+            $this->getAttributes()->merge($attributes);
         }
 
-        if ($content !== null) {
-            $this->setContent($content);
-        }
+        $this->setHtmlContent(...$content);
     }
 
     /**
      * Create a new HTML element from the given tag, attributes and content
      *
-     * @param string                 $tag        The tag for the element
-     * @param Attributes|array       $attributes The HTML attributes for the element
-     * @param ValidHtml|string|array $content    The content of the element
+     * @param string $tag        The tag for the element
+     * @param mixed  $attributes The HTML attributes for the element
+     * @param mixed  $content    The content of the element
      *
      * @return static
      */
     public static function create($tag, $attributes = null, $content = null)
     {
-        return new static($tag, $attributes, $content);
+        return new static($tag, Attributes::wantAttributes($attributes), ...Html::wantHtmlList($content));
     }
 }

--- a/src/Table.php
+++ b/src/Table.php
@@ -50,7 +50,7 @@ class Table extends BaseHtmlElement
                         break;
                     case 'caption':
                         if ($this->caption === null) {
-                            $this->prepend($html);
+                            $this->prependHtml($html);
                             $this->caption = $html;
                         } else {
                             throw new RuntimeException(
@@ -101,10 +101,10 @@ class Table extends BaseHtmlElement
     {
         if ($caption instanceof BaseHtmlElement && $caption->getTag() === 'caption') {
             $this->caption = $caption;
-            $this->prepend($caption);
+            $this->prependHtml($caption);
         } elseif ($this->caption === null) {
             $this->caption = new HtmlElement('caption', null, ...Html::wantHtmlList($caption));
-            $this->prepend($this->caption);
+            $this->prependHtml($this->caption);
         } else {
             $this->caption->setContent($caption);
         }

--- a/src/Table.php
+++ b/src/Table.php
@@ -94,7 +94,7 @@ class Table extends BaseHtmlElement
      *
      * Will be rendered as a "caption" HTML element
      *
-     * @param $caption
+     * @param mixed $caption
      * @return $this
      */
     public function setCaption($caption)
@@ -103,7 +103,7 @@ class Table extends BaseHtmlElement
             $this->caption = $caption;
             $this->prepend($caption);
         } elseif ($this->caption === null) {
-            $this->caption = new HtmlElement('caption', null, $caption);
+            $this->caption = new HtmlElement('caption', null, ...Html::wantHtmlList($caption));
             $this->prepend($this->caption);
         } else {
             $this->caption->setContent($caption);

--- a/src/Table.php
+++ b/src/Table.php
@@ -158,7 +158,7 @@ class Table extends BaseHtmlElement
     {
         $tr = static::tr();
         foreach ((array) $row as $value) {
-            $tr->add(Html::tag($tag, null, $value));
+            $tr->addHtml(Html::tag($tag, null, $value));
         }
 
         if ($attributes !== null) {

--- a/src/TemplateString.php
+++ b/src/TemplateString.php
@@ -120,7 +120,7 @@ class TemplateString extends FormattedString
             ));
         }
 
-        return (new HtmlDocument())->add(HtmlString::create($buffer));
+        return (new HtmlDocument())->addHtml(HtmlString::create($buffer));
     }
 
     /**

--- a/tests/HtmlDocumentTest.php
+++ b/tests/HtmlDocumentTest.php
@@ -162,6 +162,70 @@ class HtmlDocumentTest extends TestCase
         $this->assertEquals('Some String &lt;:-)', $a->render());
     }
 
+    public function testSetContentFlattensNestedArrays()
+    {
+        $doc = new HtmlDocument();
+        $doc->setSeparator(';');
+        $doc->setContent([
+            h::tag('span'),
+            [
+                'foo',
+                'bar',
+                [
+                    h::tag('p', 'test'),
+                    h::tag('strong', 'bla')
+                ]
+            ]
+        ]);
+        $this->assertHtml(
+            '<span></span>;foo;bar;<p>test</p>;<strong>bla</strong>',
+            $doc
+        );
+    }
+
+
+    public function testAddFlattensNestedArrays()
+    {
+        $doc = new HtmlDocument();
+        $doc->setSeparator(';');
+        $doc->add([
+            h::tag('span'),
+            [
+                'foo',
+                'bar',
+                [
+                    h::tag('p', 'test'),
+                    h::tag('strong', 'bla')
+                ]
+            ]
+        ]);
+        $this->assertHtml(
+            '<span></span>;foo;bar;<p>test</p>;<strong>bla</strong>',
+            $doc
+        );
+    }
+
+    public function testPrependFlattensNestedArrays()
+    {
+        $doc = new HtmlDocument();
+        $doc->setSeparator(';');
+        $doc->prepend([
+            h::tag('span'),
+            [
+                'foo',
+                'bar',
+                [
+                    h::tag('p', 'test'),
+                    h::tag('strong', 'bla')
+                ]
+            ]
+        ]);
+        $this->assertHtml(
+            '<span></span>;foo;bar;<p>test</p>;<strong>bla</strong>',
+            $doc
+        );
+    }
+
     public function testSkipsNullValues()
     {
         $a = new HtmlDocument();

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Html;
 
+use InvalidArgumentException;
 use ipl\Html\Html;
 
 class HtmlTest extends TestCase
@@ -16,14 +17,34 @@ class HtmlTest extends TestCase
         $html = Html::tag('div', $content());
 
         $this->assertHtml('<div><b>foo</b><b>bar</b></div>', $html);
+
+        $html = Html::tag('div', ['class' => 'foobar'], $content());
+
+        $this->assertHtml('<div class="foobar"><b>foo</b><b>bar</b></div>', $html);
     }
 
     public function testWrapsListsWithSimpleHtmlTags()
     {
-        $this->assertXmlStringEqualsXmlString(
+        $this->assertHtml(
             '<ul><li>a</li><li>b</li><li>c</li></ul>',
-            Html::tag('ul', Html::wrapEach(['a', 'b', 'c'], 'li'))->render()
+            Html::tag('ul', Html::wrapEach(['a', 'b', 'c'], 'li'))
         );
+        $this->assertHtml(
+            '<ul class="simple"><li>a</li><li>b</li><li>c</li></ul>',
+            Html::tag('ul', ['class' => 'simple'], Html::wrapEach(['a', 'b', 'c'], 'li'))
+        );
+    }
+
+    public function testTagComplainsAboutAttributesNotBeingAttributes()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Html::tag('span', ['foo-class'], ['foo-content']);
+    }
+
+    public function testTagDoesNotIgnoreContent()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        Html::tag('span', Html::tag('a'), Html::tag('b'));
     }
 
     public function testWrapsListsWithCallback()
@@ -39,13 +60,13 @@ class HtmlTest extends TestCase
             ], $value);
         }));
 
-        $this->assertXmlStringEqualsXmlString(
+        $this->assertHtml(
             '<select>'
             . '<option value="val1">Label 1</option>'
             . '<option value="val2">Label 2</option>'
             . '<option value="val3">Label 3</option>'
             . '</select>',
-            $select->render()
+            $select
         );
     }
 }


### PR DESCRIPTION
This pull request adds strict interfaces for methods `HtmlDocument::add()`, `HtmlDocument::prepend()` and `HtmlDocument::setContent()`.
These are `HtmlDocument::addHtml()`, `HtmlDocument::prependHtml()` and `HtmlDocument::setHtmlContent()` respectively.

The intention of this is to have less ambiguity for internal assemblies and definite calls during concrete assemblies.
The non-strict versions of these methods perform fuzzy matching in order to provide less rigid interfaces. Though this is sometimes not required, as there's are `ValidHtml` instances assembled in any case, so there's no need for *fuzzy* matching.

There's one breaking change though: The interface of the `HtmlElement` constructor has also changed.

This is not possible anymore:

```php
new HtmlElement('div', ['class' => 'foo'], 'text');
```

Instead the following options are possible:

```php
$a = new HtmlElement('div', Attributes::create(['class' => 'foo']), Text::create('text'));
$b = HtmlElement::create('div', ['class' => 'foo'], 'text');
```

Since #23 wasn't merged since way over a year, class `HtmlElement` has been used thoroughly. So this is a breaking change with high impact. I still consider this a good change though, because it shows how constructors should behave...