### PR TITLE
BaseHtmlElement: Render attributes after content

### DIFF
--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -320,8 +320,8 @@ abstract class BaseHtmlElement extends HtmlDocument
         $this->ensureAssembled();
 
         $tag = $this->getTag();
-        $attributes = $this->getAttributes()->render();
         $content = $this->renderContent();
+        $attributes = $this->getAttributes()->render();
 
         if (strlen($this->contentSeparator)) {
             $length = strlen($content);


### PR DESCRIPTION
This allows to conditionally provide attributes
by using callbacks that evaluate what has been
rendered as content.