### PR TITLE
Fix failed localdateTime validation in Safari

### DIFF
--- a/src/FormElement/LocalDateTimeElement.php
+++ b/src/FormElement/LocalDateTimeElement.php
@@ -10,6 +10,8 @@ class LocalDateTimeElement extends InputElement
 
     protected $type = 'datetime-local';
 
+    protected $defaultAttributes = ['step' => '1'];
+
     /** @var DateTime */
     protected $value;
 

--- a/tests/FormElement/LocalDateTimeElementTest.php
+++ b/tests/FormElement/LocalDateTimeElementTest.php
@@ -12,7 +12,10 @@ class LocalDateTimeElementTest extends TestCase
         $element = new LocalDateTimeElement('test');
         $element->setValue(DateTime::createFromFormat(LocalDateTimeElement::FORMAT, '2021-02-10T16:00:00'));
 
-        $this->assertHtml('<input type="datetime-local" name="test" value="2021-02-10T16:00:00">', $element);
+        $this->assertHtml(
+            '<input type="datetime-local" step="1" name="test" value="2021-02-10T16:00:00">',
+            $element
+        );
     }
 
     public function testReturnsADatTimeObjectOnGetValue()


### PR DESCRIPTION
This fixes the problem of failed localdateTime validation in Safari.

resolves https://github.com/Icinga/icingadb-web/issues/255