### PR TITLE
SubmitElement: Don't compare label to determine whether the submit el…

### DIFF
--- a/src/FormElement/SubmitElement.php
+++ b/src/FormElement/SubmitElement.php
@@ -40,7 +40,7 @@ class SubmitElement extends InputElement implements FormSubmitElement
 
     public function hasBeenPressed()
     {
-        return $this->getButtonLabel() === $this->getValue();
+        return (bool) $this->getValue();
     }
 
     public function isIgnored()


### PR DESCRIPTION
…ement is pressed

Actually, when the submit element label is modified afterwards (after the submit element has been registered), it doesn't detect that the element is actually pressed (the form is submitted), as the button label is compared to the actual value of
the element to determine if it is pressed.