### PR TITLE
Don't require HtmlDocument subclasses to adapt their interfaces

### DIFF
--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -431,7 +431,8 @@ class HtmlDocument implements Countable, Wrappable
         return $this->setWrapped($document)->render();
     }
 
-    public function count(): int
+    #[\ReturnTypeWillChange]
+    public function count()
     {
         return count($this->content);
     }


### PR DESCRIPTION
This change allows for zero-effort compatibility with changes related to
the PHP 8.1 support.

Of all the changes related to supporting PHP 8.1 in the IPL, the
HtmlDocument::count() change has the biggest impact as there are
subclasses in various modules whose signatures would need to be
adjusted. There is literally no other case in the IPL changes that
breaks compatibility that badly, and since HtmlDocument is designed to
be subclassed, there is no justification for introducing this change at
the moment. [1]

So instead of introducing the return type, this change relaxes PHP 8.1
compatibility by using ReturnTypeWillChange.

[1] This change should be made when we introduce strict typing
everywhere.