### PR TITLE
SelectElement:  Override existing options in `setOptions()`

### DIFF
--- a/src/FormElement/SelectElement.php
+++ b/src/FormElement/SelectElement.php
@@ -104,6 +104,7 @@ class SelectElement extends BaseFormElement
     public function setOptions(array $options)
     {
         $this->options = [];
+        $this->optionContent = [];
         foreach ($options as $value => $label) {
             $this->optionContent[$value] = $this->makeOption($value, $label);
         }


### PR DESCRIPTION
`SelectElement::setOptions($opts)` call should not add $opts to existing options, but overwrite them completely.