### PR TITLE
SelectOption: Add method `getLabel()` and change method `setLabel()`

### DIFF
--- a/src/FormElement/SelectOption.php
+++ b/src/FormElement/SelectOption.php
@@ -8,38 +8,62 @@ class SelectOption extends BaseHtmlElement
 {
     protected $tag = 'option';
 
-    /** @var mixed */
+    /** @var string|int|null Value of the option */
     protected $value;
+
+    /** @var string Label of the option */
+    protected $label;
 
     /**
      * SelectOption constructor.
-     * @param string|null $value
-     * @param string|null $label
+     *
+     * @param string|int|null $value
+     * @param string $label
      */
-    public function __construct($value = null, $label = null)
+    public function __construct($value, string $label)
     {
         $this->value = $value;
-        $this->add($label);
+        $this->label = $label;
 
         $this->getAttributes()->registerAttributeCallback('value', [$this, 'getValue']);
     }
 
     /**
-     * @param $label
+     * Set the label of the option
+     *
+     * @param string $label
+     *
      * @return $this
      */
-    public function setLabel($label)
+    public function setLabel(string $label): self
     {
-        $this->setContent($label);
+        $this->label = $label;
 
         return $this;
     }
 
     /**
+     * Get the label of the option
+     *
      * @return string
+     */
+    public function getLabel(): string
+    {
+        return $this->label;
+    }
+
+    /**
+     * Get the value of the option
+     *
+     * @return string|int|null
      */
     public function getValue()
     {
         return $this->value;
+    }
+
+    protected function assemble()
+    {
+        $this->setContent($this->getLabel());
     }
 }

--- a/tests/FormElement/SelectElementTest.php
+++ b/tests/FormElement/SelectElementTest.php
@@ -257,11 +257,4 @@ class SelectElementTest extends TestCase
             $select
         );
     }
-
-    public function testLabelCanBeChanged()
-    {
-        $option = new SelectOption('value', 'Original label');
-        $option->setLabel('New label');
-        $this->assertHtml('<option value="value">New label</option>', $option);
-    }
 }

--- a/tests/FormElement/SelectOptionTest.php
+++ b/tests/FormElement/SelectOptionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace ipl\Tests\Html\FormElement;
+
+use ipl\Html\FormElement\SelectElement;
+use ipl\Html\FormElement\SelectOption;
+use ipl\Tests\Html\TestCase;
+
+class SelectOptionTest extends TestCase
+{
+    public function testRendering()
+    {
+        $option = new SelectOption('test', 'Original label');
+
+        $this->assertHtml('<option value="test">Original label</option>', $option);
+    }
+
+    public function testRenderingAfterSetLabel()
+    {
+        $option = new SelectOption('test', 'Original label');
+        $option->setLabel('New label');
+
+        $this->assertHtml('<option value="test">New label</option>', $option);
+    }
+
+    public function testGetLabel()
+    {
+        $option = new SelectOption('test', 'Original label');
+        $this->assertSame('Original label', $option->getLabel());
+    }
+
+    public function testGetLabelAfterSetLabel()
+    {
+        $option = new SelectOption('test', 'Original label');
+        $this->assertSame('Original label', $option->getLabel());
+
+        $option->setLabel('New label');
+        $this->assertSame('New label', $option->getLabel());
+    }
+}


### PR DESCRIPTION
This PR allows to easily get the label of the selected option. `getContect()` returns an array of `ValidHtml[]` and makes it harder to get the label as string.

# Usage:
`$form->getElement('user')->getOption($form->getValue('user'))->getLabel()`