### PR TITLE
FormElements: Don't return empty values when default value is provided

### DIFF
--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -332,9 +332,14 @@ trait FormElements
      */
     public function getPopulatedValue($name, $default = null)
     {
-        return isset($this->populatedValues[$name])
-            ? $this->populatedValues[$name][count($this->populatedValues[$name]) - 1]
-            : $default;
+        if (isset($this->populatedValues[$name])) {
+            $value = $this->populatedValues[$name][count($this->populatedValues[$name]) - 1];
+            if (! empty($value)) {
+                return $value;
+            }
+        }
+
+        return $default;
     }
 
     /**


### PR DESCRIPTION
When calling `getPopulatedValue()` with a default value, it sometimes returns `null/""` of the populated value and ignores the provided default value. This fix ensures that the default value is always returned if the populated value doesn't have a valid value.