### PR TITLE
CheckboxElement::setValue(): Use loose comparison if value is numeric

### DIFF
--- a/src/FormElement/CheckboxElement.php
+++ b/src/FormElement/CheckboxElement.php
@@ -95,6 +95,8 @@ class CheckboxElement extends InputElement
             $value = $value ? $this->getCheckedValue() : $this->getUncheckedValue();
         }
 
+        $isChecked = is_numeric($value) ? $value == $this->getCheckedValue() : $value === $this->getCheckedValue();
+        $this->setChecked($isChecked);
         $this->setChecked($value === $this->getCheckedValue());
 
         return parent::setValue($value);


### PR DESCRIPTION
When checkedValue/uncheckedValue is a number, php casts it to string and strict check returns false