### PR TITLE
Make addDefaultValidators() protected and pass validator chain

### DIFF
--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -180,18 +180,12 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     public function getValidators()
     {
         if ($this->validators === null) {
-            $this->validators = new ValidatorChain();
-            $this->addDefaultValidators();
+            $chain = new ValidatorChain();
+            $this->addDefaultValidators($chain);
+            $this->validators = $chain;
         }
 
         return $this->validators;
-    }
-
-    /**
-     * Add default validators
-     */
-    public function addDefaultValidators()
-    {
     }
 
     /**
@@ -315,6 +309,13 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     public function getValueAttribute()
     {
         return $this->getValue();
+    }
+
+    /**
+     * Add default validators
+     */
+    protected function addDefaultValidators(ValidatorChain $chain): void
+    {
     }
 
     protected function registerValueCallback(Attributes $attributes)

--- a/src/FormElement/ColorElement.php
+++ b/src/FormElement/ColorElement.php
@@ -3,13 +3,14 @@
 namespace ipl\Html\FormElement;
 
 use ipl\Validator\HexColorValidator;
+use ipl\Validator\ValidatorChain;
 
 class ColorElement extends InputElement
 {
     protected $type = 'color';
 
-    public function addDefaultValidators(): void
+    protected function addDefaultValidators(ValidatorChain $chain): void
     {
-        $this->getValidators()->add(new HexColorValidator());
+        $chain->add(new HexColorValidator());
     }
 }

--- a/src/FormElement/LocalDateTimeElement.php
+++ b/src/FormElement/LocalDateTimeElement.php
@@ -4,6 +4,7 @@ namespace ipl\Html\FormElement;
 
 use DateTime;
 use ipl\Validator\DateTimeValidator;
+use ipl\Validator\ValidatorChain;
 
 class LocalDateTimeElement extends InputElement
 {
@@ -45,8 +46,8 @@ class LocalDateTimeElement extends InputElement
         return $this->value->format(static::FORMAT);
     }
 
-    public function addDefaultValidators()
+    protected function addDefaultValidators(ValidatorChain $chain): void
     {
-        $this->getValidators()->add(new DateTimeValidator());
+        $chain->add(new DateTimeValidator());
     }
 }


### PR DESCRIPTION
The chain is now passed to save calls to `getValidators()` and is now protected as it is not intended to be called outside of the class.