### PR TITLE
Clone Test

### DIFF
--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -17,7 +17,10 @@ class CloneTest extends TestCase
         $clonesButton = clone $originalButton;
         $clonesButton->getAttributes()->setAttribute(Attribute::create('class', 'class02'));
 
-        $this->assertNotSame($originalButton->getAttributes()->get('class')->getValue(), $clonesButton->getAttributes()->get('class')->getValue());
+        $this->assertNotSame(
+            $originalButton->getAttributes()->get('class')->getValue(),
+            $clonesButton->getAttributes()->get('class')->getValue()
+        );
         $this->assertNotSame($originalButton->render(), $clonesButton->render());
     }
 

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ipl\Tests\Html;
+
+use ipl\Html\Attribute;
+use ipl\Html\Attributes;
+use ipl\Html\Form;
+use ipl\Html\FormElement\SelectElement;
+use ipl\Html\FormElement\SubmitElement;
+
+class CloneTest extends TestCase
+{
+    public function testCloningSubmitElement(): void
+    {
+        $originalButton = new SubmitElement('exampleButton', ['class' => 'class01']);
+
+        $clonesButton = clone $originalButton;
+        $clonesButton->getAttributes()->setAttribute(Attribute::create('class', 'class02'));
+
+        $this->assertNotSame($originalButton->getAttributes()->get('class')->getValue(), $clonesButton->getAttributes()->get('class')->getValue());
+        $this->assertNotSame($originalButton->render(), $clonesButton->render());
+    }
+
+    public function testCloningSelectElement()
+    {
+        $original = new SelectElement('test_select', [
+            'label'   => 'Test Select',
+            'options' => [
+                1 => 'One',
+                2 => 'Two'
+            ]
+        ]);
+        $clone = clone $original;
+
+        $clone->getAttributes()->setAttribute(Attribute::create('class', 'class02'));
+
+        $this->assertNotSame($original->render(), $clone->render());
+    }
+
+    public function testCloningForm(): void
+    {
+        $original = new Form();
+        $original->addElement('input', 'test_input', [
+            'label' => 'Test Input'
+        ]);
+
+        $clone = clone $original;
+        $clone->addElement('submit', 'test_submit', [
+            'label' => 'Test Submit'
+        ]);
+        $clone->getAttributes()->setAttribute(Attribute::create('class', 'class02'));
+
+        $this->assertNotSame($original->render(), $clone->render());
+    }
+
+    public function testCloningAttributes(): void
+    {
+        $original = Attributes::create([Attribute::create('class', 'class01')]);
+
+        $clone = clone $original;
+        $clone->setAttribute(Attribute::create('class', 'class02'));
+
+        $this->assertNotSame($original, $clone);
+    }
+}


### PR DESCRIPTION
This adds a Test for confirming issues with `Attributes` in various cloned FormElements.
The main problem is the callbacks, which cannot be cloned and still point to the original Element/instance.