### PR TITLE
Don't cache element validation state

### DIFF
--- a/src/FormDecorator/DdDtDecorator.php
+++ b/src/FormDecorator/DdDtDecorator.php
@@ -51,7 +51,7 @@ class DdDtDecorator extends BaseHtmlElement implements DecoratorInterface
         $attributes = parent::getAttributes();
 
         // TODO: only when sent?!
-        if ($this->wrappedElement->hasBeenValidatedAndIsNotValid()) {
+        if ($this->wrappedElement->hasMessages()) {
             $classes = $attributes->get('class');
             if (
                 empty($classes)

--- a/src/FormDecorator/DivDecorator.php
+++ b/src/FormDecorator/DivDecorator.php
@@ -118,7 +118,7 @@ class DivDecorator extends BaseHtmlElement implements FormElementDecorator
 
     protected function assemble()
     {
-        if ($this->formElement->hasBeenValidated() && ! $this->formElement->isValid()) {
+        if ($this->formElement->hasMessages()) {
             $this->getAttributes()->add('class', static::ERROR_HINT_CLASS);
         }
 

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -30,9 +30,6 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     /** @var bool Whether the element is required */
     protected $required = false;
 
-    /** @var null|bool Whether the element is valid; null if the element has not been validated yet, bool otherwise */
-    protected $valid;
-
     /** @var ValidatorChain Registered validators */
     protected $validators;
 
@@ -41,6 +38,13 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
 
     /** @var array Value candidates of the element */
     protected $valueCandidates = [];
+
+    /**
+     * @deprecated STOP: Do not use this property!!
+     *
+     * @var bool
+     */
+    protected $valid;
 
     /**
      * Create a new form element
@@ -153,8 +157,14 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
 
     public function isValid()
     {
-        if ($this->valid === null) {
-            $this->validate();
+        if ($this->valid !== null) {
+            return $this->valid;
+        }
+
+        $valid = $this->validate();
+        // validate() may return `$this` in child classes
+        if (is_bool($valid)) {
+            return $valid;
         }
 
         return $this->valid;
@@ -165,11 +175,11 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
      *
      * @return bool
      *
-     * @deprecated Use {@link hasBeenValidated()} in combination with {@link isValid()} instead
+     * @deprecated Use {@see self::hasMessages()} instead
      */
     public function hasBeenValidatedAndIsNotValid()
     {
-        return $this->valid !== null && ! $this->valid;
+        return $this->hasBeenValidated() && ! $this->valid;
     }
 
     /**
@@ -238,7 +248,6 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
         } else {
             $this->value = $value;
         }
-        $this->valid = null;
 
         return $this;
     }
@@ -262,16 +271,19 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     /**
      * Validate the element using all registered validators
      *
-     * @return $this
+     * @return bool
      */
     public function validate()
     {
-        $this->valid = $this->getValidators()->isValid($this->getValue());
+        $valid = $this->getValidators()->isValid($this->getValue());
         $this->addMessages($this->getValidators()->getMessages());
 
-        return $this;
+        return $valid;
     }
 
+    /**
+     * @deprecated Do not use this method
+     */
     public function hasBeenValidated()
     {
         return $this->valid !== null;

--- a/src/FormElement/SelectElement.php
+++ b/src/FormElement/SelectElement.php
@@ -44,15 +44,14 @@ class SelectElement extends BaseFormElement
                 || $option->getAttributes()->has('disabled')
             )
         ) {
-            $this->valid = false;
             $this->addMessage("'$value' is not allowed here");
         } elseif ($this->isRequired() && $value === null) {
-            $this->valid = false;
+            $this->addMessage('This field is required');
         } else {
-            parent::validate();
+            return parent::validate();
         }
 
-        return $this;
+        return false;
     }
 
     public function deselect()
@@ -68,7 +67,6 @@ class SelectElement extends BaseFormElement
             $option->getAttributes()->add('disabled', true);
         }
         if ($this->getValue() == $value) {
-            $this->valid = false;
             $this->addMessage("'$value' is not allowed here");
         }
 


### PR DESCRIPTION
This change may break some div decorators and validate methods for the following modules as they use the `hasBeenValidated()`, `hasBeenValidateAndIsNotValid()` methods or have their own validation logic.

- https://github.com/Icinga/icingaweb2-module-reporting
   - `CompatDecorator` and `Flatpickr`
   - https://github.com/Icinga/icingaweb2-module-reporting/pull/168
- https://github.com/Icinga/icingaweb2-module-jira
   - `LegacyDecorator`
   - https://github.com/Icinga/icingaweb2-module-jira/pull/90
- https://github.com/gipfl/web
   - `MultiSelect` element
   - https://github.com/gipfl/web/pull/2