### PR TITLE
Attribute: Allow separator customization

### DIFF
--- a/src/Attribute.php
+++ b/src/Attribute.php
@@ -18,6 +18,9 @@ class Attribute
     /** @var string */
     protected $name;
 
+    /** @var string The separator used if value is an array */
+    protected $separator = ' ';
+
     /** @var string|array|bool|null */
     protected $value;
 
@@ -150,6 +153,30 @@ class Attribute
         }
 
         $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Get the separator by which multiple values are concatenated with
+     *
+     * @return string
+     */
+    public function getSeparator(): string
+    {
+        return $this->separator;
+    }
+
+    /**
+     * Set the separator to concatenate multiple values with
+     *
+     * @param string $separator
+     *
+     * @return $this
+     */
+    public function setSeparator(string $separator): self
+    {
+        $this->separator = $separator;
 
         return $this;
     }
@@ -296,6 +323,6 @@ class Attribute
      */
     public function renderValue()
     {
-        return static::escapeValue($this->value);
+        return static::escapeValue($this->value, $this->separator);
     }
 }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -22,6 +22,16 @@ class AttributeTest extends TestCase
         );
     }
 
+    public function testCustomSeparatorIsUsed()
+    {
+        $this->assertSame(
+            'accept="image/png, image/jpg"',
+            (new Attribute('accept', ['image/png', 'image/jpg']))
+                ->setSeparator(', ')
+                ->render()
+        );
+    }
+
     public function testAttributeNameCanBeRetrieved()
     {
         $this->assertEquals(


### PR DESCRIPTION
Some require a comma, e.g. the file input's accept attribute