### PR TITLE
BaseFormElement: Call `init()` before adding attributes

### DIFF
--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -55,12 +55,12 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
      */
     public function __construct($name, $attributes = null)
     {
+        $this->setName($name);
+        $this->init();
+
         if ($attributes !== null) {
             $this->addAttributes($attributes);
         }
-        $this->setName($name);
-
-        $this->init();
     }
 
     public function getDescription()


### PR DESCRIPTION
https://github.com/Icinga/ipl-web/pull/101 is the only user of `init` currently and profits from this change.