### PR TITLE
Clone attributes

### DIFF
--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -518,4 +518,11 @@ class Attributes implements ArrayAccess, IteratorAggregate
     {
         return new ArrayIterator($this->attributes);
     }
+
+    public function __clone()
+    {
+        foreach ($this->attributes as &$attribute) {
+            $attribute = clone $attribute;
+        }
+    }
 }

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -365,29 +365,19 @@ class Attributes implements ArrayAccess, IteratorAggregate
     /**
      * Register callback for an attribute
      *
-     * @param string   $name            Name of the attribute to register the callback for
-     * @param callable $callback        Callback to call when retrieving the attribute
-     * @param callable $setterCallback  Callback to call when setting the attribute
+     * @param string    $name           Name of the attribute to register the callback for
+     * @param ?callable $callback       Callback to call when retrieving the attribute
+     * @param ?callable $setterCallback Callback to call when setting the attribute
      *
      * @return $this
-     *
-     * @throws InvalidArgumentException If $callback is not callable or if $setterCallback is set and not callable
      */
-    public function registerAttributeCallback($name, $callback, $setterCallback = null)
+    public function registerAttributeCallback(string $name, ?callable $callback, ?callable $setterCallback = null): self
     {
         if ($callback !== null) {
-            if (! is_callable($callback)) {
-                throw new InvalidArgumentException(__METHOD__ . ' expects a callable callback');
-            }
-
             $this->callbacks[$name] = $callback;
         }
 
         if ($setterCallback !== null) {
-            if (! is_callable($setterCallback)) {
-                throw new InvalidArgumentException(__METHOD__ . ' expects a callable setterCallback');
-            }
-
             $this->setterCallbacks[$name] = $setterCallback;
         }
 

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -352,4 +352,13 @@ abstract class BaseHtmlElement extends HtmlDocument
             $tag
         );
     }
+
+    public function __clone()
+    {
+        parent::__clone();
+
+        if ($this->attributes !== null) {
+            $this->attributes = clone $this->attributes;
+        }
+    }
 }

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -2,8 +2,11 @@
 
 namespace ipl\Tests\Html;
 
+use ipl\Html\Attribute;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
+use ipl\Html\HtmlString;
+use ipl\Html\ValidHtml;
 
 class AttributesTest extends TestCase
 {
@@ -112,5 +115,47 @@ class AttributesTest extends TestCase
         $attributes->set('bar', 'foo');
 
         $this->assertEquals(' foo="bar rab" bar="foo"', $attributes->render());
+    }
+
+    public function testClone(): void
+    {
+        $original = Attributes::create([
+            'class' => 'original-class',
+            'value' => 'original-value'
+        ]);
+
+        $clone = clone $original;
+        $clone->get('class')->setValue('clone-class');
+        $clone->get('name')->setValue('clone-name');
+        $clone->remove('value');
+
+        $cloneCone = clone $clone;
+        $cloneCone->get('class')->addValue('clone-clone-class');
+        $cloneCone->get('name')->setValue('clone-clone-name');
+        $cloneCone->get('value')->setValue('clone-clone-value');
+
+        $this->assertSame('original-class', $original->get('class')->getValue());
+        $this->assertSame('original-value', $original->get('value')->getValue());
+        $this->assertNull($original->get('name')->getValue());
+        $this->assertSame(
+            ' class="original-class" value="original-value"',
+            $original->render()
+        );
+
+        $this->assertSame('clone-class', $clone->get('class')->getValue());
+        $this->assertNull($clone->get('value')->getValue());
+        $this->assertSame('clone-name', $clone->get('name')->getValue());
+        $this->assertSame(
+            ' class="clone-class" name="clone-name"',
+            $clone->render()
+        );
+
+        $this->assertSame(['clone-class', 'clone-clone-class'], $cloneCone->get('class')->getValue());
+        $this->assertSame('clone-clone-name', $cloneCone->get('name')->getValue());
+        $this->assertSame('clone-clone-value', $cloneCone->get('value')->getValue());
+        $this->assertSame(
+            ' class="clone-class clone-clone-class" name="clone-clone-name" value="clone-clone-value"',
+            $cloneCone->render()
+        );
     }
 }


### PR DESCRIPTION
Right now we have an attribute cloning use case where we [duplicate the primary submit button](https://github.com/Icinga/ipl-web/pull/104) and add it as the first element to ensure that it is used for implicit form submission. The submit button to be cloned can have attributes and callbacks that must also be present on the clone, such as `formaction`, `formmethod` and `formnovalidate`, so simply not using the original attributes is not an option.

Until [proper cloning](https://github.com/Icinga/ipl-html/pull/96) is implemented, it is imperative to re-register attribute callbacks for attributes where a callback exists and the clone provides a changed value.
