### PR TITLE
Let `FileElement` add proper form attribute `enctype` and document file persistence drawbacks

### DIFF
--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -282,12 +282,12 @@ class Attributes implements ArrayAccess, IteratorAggregate
      * @param string            $name  The name of the attribute
      * @param null|string|array $value The value to remove if specified
      *
-     * @return Attribute|false
+     * @return ?Attribute The removed or changed attribute, if any, otherwise null
      */
-    public function remove($name, $value = null)
+    public function remove($name, $value = null): ?Attribute
     {
         if (! $this->has($name)) {
-            return false;
+            return null;
         }
 
         $attribute = $this->attributes[$name];

--- a/src/BaseHtmlElement.php
+++ b/src/BaseHtmlElement.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Html;
 
+use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -114,6 +115,34 @@ abstract class BaseHtmlElement extends HtmlDocument
     }
 
     /**
+     * Return true if the attribute with the given name exists, false otherwise
+     *
+     * @param string $name
+     *
+     * @return bool
+     */
+    public function hasAttribute(string $name): bool
+    {
+        return $this->getAttributes()->has($name);
+    }
+
+    /**
+     * Get the attribute with the given name
+     *
+     * If the attribute does not already exist, an empty one is automatically created and added to the attributes.
+     *
+     * @param string $name
+     *
+     * @return Attribute
+     *
+     * @throws InvalidArgumentException If the attribute does not yet exist and its name contains special characters
+     */
+    public function getAttribute(string $name): Attribute
+    {
+        return $this->getAttributes()->get($name);
+    }
+
+    /**
      * Set the attribute with the given name and value
      *
      * If the attribute with the given name already exists, it gets overridden.
@@ -128,6 +157,19 @@ abstract class BaseHtmlElement extends HtmlDocument
         $this->getAttributes()->set($name, $value);
 
         return $this;
+    }
+
+    /**
+     * Remove the attribute with the given name or remove the given value from the attribute
+     *
+     * @param string $name  The name of the attribute
+     * @param null|string|array $value The value to remove if specified
+     *
+     * @return ?Attribute The removed or changed attribute, if any, otherwise null
+     */
+    public function removeAttribute(string $name, $value = null): ?Attribute
+    {
+        return $this->getAttributes()->remove($name, $value);
     }
 
     /**

--- a/src/FormElement/FileElement.php
+++ b/src/FormElement/FileElement.php
@@ -40,7 +40,7 @@ class FileElement extends InputElement
     /** @var string[] Files to be removed from disk */
     protected $filesToRemove = [];
 
-    /** @var ?string The path where to store the file contents */
+    /** @var ?string Path to store files to preserve them across requests */
     protected $destination;
 
     /** @var int The default maximum file size */
@@ -54,7 +54,16 @@ class FileElement extends InputElement
     }
 
     /**
-     * Set the path where to store the file contents
+     * Set the path to store files to preserve them across requests
+     *
+     * Uploaded files are moved to the given directory to
+     * retain the file through automatic form submissions and failed form validations.
+     *
+     * Please note that using file persistence currently has the following drawbacks:
+     *
+     * * Works only if the file element is added to the form during {@link Form::assemble()}.
+     * * Persisted files are not removed automatically.
+     * * Files with the same name override each other.
      *
      * @param string $path
      *
@@ -68,9 +77,9 @@ class FileElement extends InputElement
     }
 
     /**
-     * Get the path where file contents are stored
+     * Get the path to store files to preserve them across requests
      *
-     * @return ?string
+     * @return string
      */
     public function getDestination(): ?string
     {

--- a/src/FormElement/FileElement.php
+++ b/src/FormElement/FileElement.php
@@ -18,6 +18,12 @@ use ipl\Html\Common\MultipleAttribute;
 
 use function ipl\Stdlib\get_php_type;
 
+/**
+ * File upload element
+ *
+ * Once the file element is added to the form and the form attribute `enctype` is not set,
+ * it is automatically set to `multipart/form-data`.
+ */
 class FileElement extends InputElement
 {
     use MultipleAttribute;
@@ -241,6 +247,10 @@ class FileElement extends InputElement
 
     public function onRegistered(Form $form)
     {
+        if (! $form->hasAttribute('enctype')) {
+            $form->setAttribute('enctype', 'multipart/form-data');
+        }
+
         $chosenFiles = (array) $form->getPopulatedValue('chosen_file_' . $this->getName(), []);
         foreach ($chosenFiles as $chosenFile) {
             $this->files[$chosenFile] = null;

--- a/src/FormElement/FileElement.php
+++ b/src/FormElement/FileElement.php
@@ -54,6 +54,16 @@ class FileElement extends InputElement
     }
 
     /**
+     * Get the path to store files to preserve them across requests
+     *
+     * @return string
+     */
+    public function getDestination(): ?string
+    {
+        return $this->destination;
+    }
+
+    /**
      * Set the path to store files to preserve them across requests
      *
      * Uploaded files are moved to the given directory to
@@ -74,16 +84,6 @@ class FileElement extends InputElement
         $this->destination = $path;
 
         return $this;
-    }
-
-    /**
-     * Get the path to store files to preserve them across requests
-     *
-     * @return string
-     */
-    public function getDestination(): ?string
-    {
-        return $this->destination;
     }
 
     public function getValueAttribute()


### PR DESCRIPTION
File upload only works if the form's `encytype` attribute is set to `multipart/form-data`. With this PR, the `FileElement` will automatically set this on the form where it will be added if it doesn't already exist.

Also, file upload persistence drawbacks are now documented in `FileElement::setDestination()`.

The above changes also required the following adjustments:

* `Attributes::remove()` now returns `null` instead of `false` to support specifying a proper return type declaration.
* `BaseHtmlElement` now proxies more `Attributes` methods to conveniently change attributes on the element directly. We already had `setAttribute()`. 