### PR TITLE
SubmitButtonElement: Set the submit value by the `value` attribute

### DIFF
--- a/src/FormElement/SubmitButtonElement.php
+++ b/src/FormElement/SubmitButtonElement.php
@@ -55,7 +55,7 @@ class SubmitButtonElement extends ButtonElement implements FormSubmitElement
     {
         parent::registerAttributeCallbacks($attributes);
 
-        $attributes->registerAttributeCallback('submitValue', null, [$this, 'setSubmitValue']);
+        $attributes->registerAttributeCallback('value', null, [$this, 'setSubmitValue']);
     }
 
     public function getValueAttribute()

--- a/tests/FormElement/SubmitButtonElementTest.php
+++ b/tests/FormElement/SubmitButtonElementTest.php
@@ -30,4 +30,37 @@ class SubmitButtonElementTest extends TestCase
             'A submit button is pressed even if another one is'
         );
     }
+
+    public function testSubmitButtonsWithSameNameCanBeDifferentiated()
+    {
+        $form = new class extends Form {
+            protected function assemble()
+            {
+                $this->addElement('submitButton', 'a_button', [
+                    'value' => 'a'
+                ]);
+                $this->addHtml($this->createElement('submitButton', 'a_button', [
+                    'value' => 'b'
+                ]));
+            }
+        };
+
+        $form->populate(['a_button' => 'a']);
+        $form->ensureAssembled(); // handleRequest usually assembles
+
+        $this->assertSame(
+            'a',
+            $form->getValue('a_button'),
+            'Multiple submit buttons with the same name cannot be differentiated by their value'
+        );
+
+        $html = <<<'HTML'
+<form method="POST">
+      <button name="a_button" type="submit" value="a"/>
+      <button name="a_button" type="submit" value="b"/>
+</form>
+HTML;
+
+        $this->assertHtml($html, $form);
+    }
 }


### PR DESCRIPTION
Some forms still use `value` to define the submit value. It shouldn't make a difference to use it as submit value internally now, as the end result in HTML is the same.