### PR TITLE
FormElements: Change visiblity of some private properties to protected

### DIFF
--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -244,8 +244,15 @@ trait FormElements
         } else {
             $this->ensureDefaultElementDecoratorLoaderRegistered();
 
-            $d = $this->loadPlugin('decorator', $decorator);
+            $class = $this->loadPlugin('decorator', $decorator);
+            if (! $class) {
+                throw new InvalidArgumentException(sprintf(
+                    "Can't create decorator of unknown type '%s",
+                    $decorator
+                ));
+            }
 
+            $d = new $class();
             if (! $d instanceof FormElementDecorator && ! $d instanceof DecoratorInterface) {
                 throw new InvalidArgumentException(sprintf(
                     "Expected instance of %s for decorator '%s',"

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -24,10 +24,10 @@ trait FormElements
     private $defaultElementDecorator;
 
     /** @var bool Whether the default element decorator loader has been registered */
-    private $defaultElementDecoratorLoaderRegistered = false;
+    protected $defaultElementDecoratorLoaderRegistered = false;
 
     /** @var bool Whether the default element loader has been registered */
-    private $defaultElementLoaderRegistered = false;
+    protected $defaultElementLoaderRegistered = false;
 
     /** @var FormElement[] */
     private $elements = [];

--- a/tests/FormElementsTest.php
+++ b/tests/FormElementsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace ipl\Tests\Html;
+
+use ipl\Html\Form;
+use ipl\Html\FormElement\FormElements;
+
+class FormElementsTest extends TestCase
+{
+    public function testFormWithCustomElementLoader()
+    {
+        $form = $this->getFormWithCustomElementAndDecoratorLoader();
+
+        $form->addElement('text', 'test');
+
+        $this->assertTrue($form->hasEnsureDefaultElementLoaderRegisteredRun());
+    }
+
+    public function testFormWithCustomDecoratorLoader()
+    {
+        $form = $this->getFormWithCustomElementAndDecoratorLoader();
+
+        $form->setDefaultElementDecorator('div');
+
+        $this->assertTrue($form->hasEnsureDefaultElementDecoratorLoaderRegisteredRun());
+    }
+
+    private function getFormWithCustomElementAndDecoratorLoader()
+    {
+        return new class extends Form {
+            use FormElements;
+
+            /** @var bool */
+            private $ensureDefaultElementLoaderRegisteredRun = false;
+
+            /** @var bool */
+            private $ensureDefaultElementDecoratorLoaderRegisteredRun = false;
+
+            public function hasEnsureDefaultElementLoaderRegisteredRun(): bool
+            {
+                return $this->ensureDefaultElementLoaderRegisteredRun;
+            }
+
+            public function hasEnsureDefaultElementDecoratorLoaderRegisteredRun(): bool
+            {
+                return $this->ensureDefaultElementDecoratorLoaderRegisteredRun;
+            }
+
+            protected function ensureDefaultElementLoaderRegistered()
+            {
+                if (! $this->defaultElementLoaderRegistered) {
+                    $this->ensureDefaultElementLoaderRegisteredRun = true;
+
+                    parent::ensureDefaultElementLoaderRegistered();
+                }
+
+                return $this;
+            }
+
+            protected function ensureDefaultElementDecoratorLoaderRegistered()
+            {
+                if (! $this->defaultElementDecoratorLoaderRegistered) {
+                    $this->ensureDefaultElementDecoratorLoaderRegisteredRun = true;
+
+                    parent::ensureDefaultElementDecoratorLoaderRegistered();
+                }
+
+                return $this;
+            }
+        };
+    }
+}


### PR DESCRIPTION
The methods using them are protected and can be overridden. But since the properties are private, and used internally as flag to do things only once, a child class cannot override them without using its own flags.

Also fixes an issue with `setDefaultElementDecorator()` as it accepts strings but doesn't instantiate the class return by a loader.