### PR TITLE
Catch `\Throwable` instead of `\Exception`

### DIFF
--- a/src/DeferredText.php
+++ b/src/DeferredText.php
@@ -2,7 +2,7 @@
 
 namespace ipl\Html;
 
-use Exception;
+use Throwable;
 
 /**
  * Text node where content creation is deferred until rendering
@@ -96,7 +96,7 @@ class DeferredText implements ValidHtml
     {
         try {
             return $this->render();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return Error::render($e);
         }
     }

--- a/src/Form.php
+++ b/src/Form.php
@@ -2,12 +2,12 @@
 
 namespace ipl\Html;
 
-use Exception;
 use ipl\Html\Contract\FormElement;
 use ipl\Html\Contract\FormSubmitElement;
 use ipl\Html\FormElement\FormElements;
 use ipl\Stdlib\Messages;
 use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
 
 class Form extends BaseHtmlElement
 {
@@ -237,7 +237,7 @@ class Form extends BaseHtmlElement
                     $this->emit(Form::ON_SENT, [$this]);
                     $this->onSuccess();
                     $this->emitOnce(Form::ON_SUCCESS, [$this]);
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     $this->addMessage($e);
                     $this->onError();
                     $this->emit(Form::ON_ERROR, [$e, $this]);
@@ -363,7 +363,7 @@ class Form extends BaseHtmlElement
     {
         $errors = Html::tag('ul', ['class' => 'errors']);
         foreach ($this->getMessages() as $message) {
-            if ($message instanceof Exception) {
+            if ($message instanceof Throwable) {
                 $message = $message->getMessage();
             }
 

--- a/src/FormattedString.php
+++ b/src/FormattedString.php
@@ -2,8 +2,8 @@
 
 namespace ipl\Html;
 
-use Exception;
 use InvalidArgumentException;
+use Throwable;
 
 use function ipl\Stdlib\get_php_type;
 
@@ -86,7 +86,7 @@ class FormattedString implements ValidHtml
     {
         try {
             return $this->render();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return Error::render($e);
         }
     }

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -3,11 +3,11 @@
 namespace ipl\Html;
 
 use Countable;
-use Exception;
 use InvalidArgumentException;
 use ipl\Html\Contract\Wrappable;
 use ipl\Stdlib\Events;
 use RuntimeException;
+use Throwable;
 
 /**
  * HTML document
@@ -418,7 +418,7 @@ class HtmlDocument implements Countable, Wrappable
     {
         try {
             return $this->render();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return Error::render($e);
         }
     }

--- a/src/Text.php
+++ b/src/Text.php
@@ -2,7 +2,7 @@
 
 namespace ipl\Html;
 
-use Exception;
+use Throwable;
 
 /**
  * A text node
@@ -100,7 +100,7 @@ class Text implements ValidHtml
     {
         try {
             return $this->render();
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             return Error::render($e);
         }
     }


### PR DESCRIPTION
`\Throwable` is the base for all errors and exceptions since PHP 7.