### PR TITLE
Fix password replacement for unsubmitted and unsaved forms

### DIFF
--- a/src/FormElement/PasswordElement.php
+++ b/src/FormElement/PasswordElement.php
@@ -15,6 +15,9 @@ class PasswordElement extends InputElement
     /** @var bool Status of the form */
     protected $isFormValid = true;
 
+    /** @var bool Status indicating if the form got submitted */
+    protected $isFormSubmitted = false;
+
     protected function registerAttributeCallbacks(Attributes $attributes)
     {
         parent::registerAttributeCallbacks($attributes);
@@ -22,11 +25,16 @@ class PasswordElement extends InputElement
         $attributes->registerAttributeCallback(
             'value',
             function () {
-                if ($this->hasValue() && count($this->getValueCandidates()) === 1 && $this->isFormValid) {
+                if (
+                    $this->hasValue()
+                    && count($this->getValueCandidates()) === 1
+                    && $this->isFormValid
+                    && ! $this->isFormSubmitted
+                ) {
                     return self::DUMMYPASSWORD;
                 }
 
-                if (parent::getValue() === self::DUMMYPASSWORD) {
+                if (parent::getValue() === self::DUMMYPASSWORD && count($this->getValueCandidates()) > 1) {
                     return self::DUMMYPASSWORD;
                 }
 
@@ -39,6 +47,10 @@ class PasswordElement extends InputElement
     {
         $form->on(Form::ON_VALIDATE, function ($form) {
             $this->isFormValid = $form->isValid();
+        });
+
+        $form->on(Form::ON_SENT, function ($form) {
+            $this->isFormSubmitted = $form->hasBeenSent();
         });
     }
 


### PR DESCRIPTION
The password replacement should not get triggered on unsubmitted forms and on forms that have not been persisted yet (which gets caused by autosubmits, validations, etc...).

@nilmerg I kept the validity check as it would break https://github.com/Icinga/ipl-html/pull/57#discussion_r759344524 when removed. It still works as expected. Adding and saving a new transport command with wrong credentials still suppresses the password replacement.

Resolves: https://github.com/Icinga/icinga-notifications-web/issues/224