### PR TITLE
Check if actual checkbox value equals checkedValue

### DIFF
--- a/src/FormElement/CheckboxElement.php
+++ b/src/FormElement/CheckboxElement.php
@@ -121,4 +121,13 @@ class CheckboxElement extends InputElement
 
         return (new HiddenElement($this->getValueOfNameAttribute(), ['value' => $this->getUncheckedValue()])) . $html;
     }
+
+    /**
+     * Determine if the checkbox is considered "checked".
+     * Returns true if the current value matches the checked value, otherwise false.
+     */
+    public function hasValue(): bool
+    {
+        return $this->getValue() === $this->getCheckedValue();
+    }
 }

--- a/tests/FormElement/CheckboxElementTest.php
+++ b/tests/FormElement/CheckboxElementTest.php
@@ -3,9 +3,16 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\FormElement\CheckboxElement;
+use ipl\I18n\NoopTranslator;
+use ipl\I18n\StaticTranslator;
 
 class CheckboxElementTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+    }
+
     public function testRendersCheckValuesAsValueAttribute()
     {
         $checkbox = new CheckboxElement('test');
@@ -105,5 +112,14 @@ class CheckboxElementTest extends TestCase
             . '<input checked="checked" type="checkbox" name="test" value="checked">',
             $checkbox
         );
+    }
+
+    public function testCheckboxNotValidIfRequiredAndUnchecked()
+    {
+        $checkbox = new CheckboxElement('test');
+        $checkbox->setRequired();
+        $checkbox->setChecked(false);
+
+        $this->assertFalse($checkbox->isValid());
     }
 }


### PR DESCRIPTION
Override method `hasValue()` from `BaseFormElement` in `CheckboxElement`.

Fix #143 