### PR TITLE
Deprecate interface Wrappable

### DIFF
--- a/src/Contract/Wrappable.php
+++ b/src/Contract/Wrappable.php
@@ -2,10 +2,13 @@
 
 namespace ipl\Html\Contract;
 
+use ipl\Html\HtmlDocument;
 use ipl\Html\ValidHtml;
 
 /**
  * Representation of wrappable elements
+ *
+ * @deprecated Use {@see HtmlDocument} instead.
  */
 interface Wrappable extends ValidHtml
 {

--- a/src/FormElement/FieldsetElement.php
+++ b/src/FormElement/FieldsetElement.php
@@ -7,6 +7,7 @@ use ipl\Html\Common\MultipleAttribute;
 use ipl\Html\Contract\FormElement;
 use ipl\Html\Contract\FormElementDecorator;
 use ipl\Html\Contract\Wrappable;
+use ipl\Html\HtmlDocument;
 use LogicException;
 
 use function ipl\Stdlib\get_php_type;
@@ -94,7 +95,7 @@ class FieldsetElement extends BaseFormElement
         return null;
     }
 
-    public function setWrapper(Wrappable $wrapper)
+    public function setWrapper(HtmlDocument|Wrappable $wrapper)
     {
         // TODO(lippserd): Revise decorator implementation to properly implement decorator propagation
         if (


### PR DESCRIPTION
The implementation of this interface in the `HtmlDocument` class requires the property of the class (`HtmlDocument::renderWrapped()` uses the `renderedBy` property). This means that a `Wrappable` instance must actually also be an `HtmlDocument` instance. This in turn means that `Wrappable` can be removed (deprecate) and the `HtmlDocument` can be used directly instead.