### PR TITLE
FormDecorator: Do not expect form elements to be HTML elements

### DIFF
--- a/src/Contract/Decorator.php
+++ b/src/Contract/Decorator.php
@@ -47,9 +47,9 @@ interface Decorator
      * ```
      *
      * @param DecorationResults $results
-     * @param FormElement & HtmlElementInterface $formElement
+     * @param FormElement $formElement
      *
      * @return void
      */
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void;
+    public function decorate(DecorationResults $results, FormElement $formElement): void;
 }

--- a/src/FormDecorator/DescriptionDecorator.php
+++ b/src/FormDecorator/DescriptionDecorator.php
@@ -50,16 +50,17 @@ class DescriptionDecorator implements Decorator, DecoratorOptionsInterface
         return 'Description';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $description = $formElement->getDescription();
+        $isHtmlElement = $formElement instanceof HtmlElementInterface;
 
-        if ($description === null || $formElement->getTag() === 'fieldset') {
+        if ($description === null || $isHtmlElement && $formElement->getTag() === 'fieldset') {
             return;
         }
 
         $descriptionId = null;
-        if ($formElement->getAttributes()->has('id')) {
+        if ($isHtmlElement && $formElement->getAttributes()->has('id')) {
             $descriptionId = 'desc_' . $formElement->getAttributes()->get('id')->getValue();
             $formElement->getAttributes()->set('aria-describedby', $descriptionId);
         }

--- a/src/FormDecorator/ErrorsDecorator.php
+++ b/src/FormDecorator/ErrorsDecorator.php
@@ -7,7 +7,6 @@ use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\DecoratorOptions;
 use ipl\Html\Contract\DecoratorOptionsInterface;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
 
@@ -50,7 +49,7 @@ class ErrorsDecorator implements Decorator, DecoratorOptionsInterface
         return 'Errors';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $errors = new HtmlElement('ul', new Attributes(['class' => $this->getClass()]));
         foreach ($formElement->getMessages() as $message) {

--- a/src/FormDecorator/FieldsetDecorator.php
+++ b/src/FormDecorator/FieldsetDecorator.php
@@ -20,9 +20,10 @@ class FieldsetDecorator implements Decorator
         return 'Fieldset';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
-        if (! $formElement instanceof MutableHtml || $formElement->getTag() !== 'fieldset') {
+        $isHtmlElement = $formElement instanceof HtmlElementInterface;
+        if (! $formElement instanceof MutableHtml || ! $isHtmlElement || $formElement->getTag() !== 'fieldset') {
             return;
         }
 

--- a/src/FormDecorator/HtmlTagDecorator.php
+++ b/src/FormDecorator/HtmlTagDecorator.php
@@ -8,7 +8,6 @@ use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\DecoratorOptions;
 use ipl\Html\Contract\DecoratorOptionsInterface;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\HtmlElement;
 use RuntimeException;
 use Throwable;
@@ -32,7 +31,7 @@ class HtmlTagDecorator implements Decorator, DecoratorOptionsInterface
     /** @var string HTML tag to use for the decoration. */
     protected string $tag;
 
-    /** @var ?callable(FormElement & HtmlElementInterface): bool Callable to decide whether to decorate the element */
+    /** @var ?callable(FormElement): bool Callable to decide whether to decorate the element */
     protected $condition;
 
     /** @var ?(string|string[]) CSS classes to apply */
@@ -95,7 +94,7 @@ class HtmlTagDecorator implements Decorator, DecoratorOptionsInterface
     /**
      * Get the condition callable to decide whether to decorate the element
      *
-     * @return ?callable(FormElement & HtmlElementInterface): bool
+     * @return ?callable(FormElement): bool
      */
     public function getCondition(): ?callable
     {
@@ -105,7 +104,7 @@ class HtmlTagDecorator implements Decorator, DecoratorOptionsInterface
     /**
      * Set the condition callable to decide whether to decorate the element
      *
-     * @param callable(FormElement & HtmlElementInterface): bool $condition
+     * @param callable(FormElement): bool $condition
      *
      * @return $this
      */
@@ -149,7 +148,7 @@ class HtmlTagDecorator implements Decorator, DecoratorOptionsInterface
      * @throws InvalidArgumentException if the condition callback does not return a boolean
      * @throws RuntimeException if the condition callback throws an exception
      */
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $condition = $this->getCondition();
         if ($condition !== null) {

--- a/src/FormDecorator/LabelDecorator.php
+++ b/src/FormDecorator/LabelDecorator.php
@@ -51,18 +51,20 @@ class LabelDecorator implements Decorator, DecoratorOptionsInterface
         return 'Label';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
+        $isHtmlElement = $formElement instanceof HtmlElementInterface;
+
         if (
             $formElement instanceof FormSubmitElement
-            || $formElement->getTag() === 'fieldset'
             || $formElement->getLabel() === null
+            || $isHtmlElement && $formElement->getTag() === 'fieldset'
         ) {
             return;
         }
 
         $labelAttr = new Attributes(['class' => $this->getClass()]);
-        if ($formElement->getAttributes()->has('id')) {
+        if ($isHtmlElement && $formElement->getAttributes()->has('id')) {
             $labelAttr->add(['for' => $formElement->getAttributes()->get('id')->getValue()]);
         }
 

--- a/src/FormDecorator/RenderElementDecorator.php
+++ b/src/FormDecorator/RenderElementDecorator.php
@@ -4,7 +4,6 @@ namespace ipl\Html\FormDecorator;
 
 use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 
 /**
  * Render the form element itself
@@ -16,7 +15,7 @@ class RenderElementDecorator implements Decorator
         return 'RenderElement';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $results->append($formElement);
     }

--- a/tests/FormDecorator/DescriptionDecoratorTest.php
+++ b/tests/FormDecorator/DescriptionDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Html\FormDecorator;
 
+use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\FormDecorator\DescriptionDecorator;
 use ipl\Html\FormElement\FieldsetElement;
@@ -86,5 +87,17 @@ class DescriptionDecoratorTest extends TestCase
         $this->decorator->decorate($results, new FieldsetElement('test'));
 
         $this->assertSame('', $results->render());
+    }
+
+    public function testNonHtmlFormElementsAreSupported(): void
+    {
+        $results = new DecorationResults();
+        $element = $this->createStub(FormElement::class);
+        $element->method('getDescription')->willReturn('Testing');
+        $element->expects($this->never())->method('getAttributes');
+
+        $this->decorator->decorate($results, $element);
+
+        $this->assertHtml('<p class="form-element-description">Testing</p>', $results);
     }
 }

--- a/tests/FormDecorator/ErrorsDecoratorTest.php
+++ b/tests/FormDecorator/ErrorsDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Html\FormDecorator;
 
+use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\FormDecorator\ErrorsDecorator;
 use ipl\Html\FormElement\TextElement;
@@ -54,6 +55,24 @@ class ErrorsDecoratorTest extends TestCase
             $results,
             (new TextElement('test'))->setMessages(['First error', 'Second error'])
         );
+
+        $html = <<<HTML
+<ul class="form-element-errors">
+  <li>First error</li>
+  <li>Second error</li>
+</ul>
+HTML;
+
+        $this->assertHtml($html, $results);
+    }
+
+    public function testNonHtmlFormElementsAreSupported(): void
+    {
+        $results = new DecorationResults();
+        $element = $this->createStub(FormElement::class);
+        $element->method('getMessages')->willReturn(['First error', 'Second error']);
+
+        $this->decorator->decorate($results, $element);
 
         $html = <<<HTML
 <ul class="form-element-errors">

--- a/tests/FormDecorator/FieldsetDecoratorTest.php
+++ b/tests/FormDecorator/FieldsetDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Html\FormDecorator;
 
+use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\FormDecorator\FieldsetDecorator;
 use ipl\Html\FormElement\FieldsetElement;
@@ -105,6 +106,16 @@ HTML;
         $this->decorator->decorate($results, new FieldsetElement('test', ['label' => 'Testing']));
         $this->decorator->decorate($results, new FieldsetElement('test', ['label' => 'Testing']));
         $this->decorator->decorate($results, new FieldsetElement('test', ['label' => 'Testing']));
+
+        $this->assertEmpty($results->render());
+    }
+
+    public function testNonHtmlFormElementsAreIgnored(): void
+    {
+        $results = new DecorationResults();
+        $element = $this->createStub(FormElement::class);
+
+        $this->decorator->decorate($results, $element);
 
         $this->assertEmpty($results->render());
     }

--- a/tests/FormDecorator/HtmlTagDecoratorTest.php
+++ b/tests/FormDecorator/HtmlTagDecoratorTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html\FormDecorator;
 
 use InvalidArgumentException;
+use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\FormDecorator\HtmlTagDecorator;
 use ipl\Html\FormDecorator\Transformation;
@@ -140,6 +141,26 @@ HTML;
         $html = <<<'HTML'
 <div></div>
 <input type="text" name="test">
+HTML;
+
+        $this->assertHtml($html, $results);
+    }
+
+    public function testNonHtmlFormElementsAreSupported(): void
+    {
+        $results = new DecorationResults();
+        $element = $this->createStub(FormElement::class);
+        $element->method('render')->willReturn('<input type="text" name="test">');
+
+        $this->decorator->setTag('div');
+        $results->append($element);
+
+        $this->decorator->decorate($results, $element);
+
+        $html = <<<'HTML'
+<div>
+  <input type="text" name="test">
+</div>
 HTML;
 
         $this->assertHtml($html, $results);

--- a/tests/FormDecorator/LabelDecoratorTest.php
+++ b/tests/FormDecorator/LabelDecoratorTest.php
@@ -2,6 +2,7 @@
 
 namespace ipl\Tests\Html\FormDecorator;
 
+use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\FormDecorator\LabelDecorator;
 use ipl\Html\FormElement\FieldsetElement;
@@ -93,5 +94,17 @@ class LabelDecoratorTest extends TestCase
         $this->decorator->decorate($results, new SubmitElement('test'));
 
         $this->assertSame('', $results->render());
+    }
+
+    public function testNonHtmlFormElementsAreSupported(): void
+    {
+        $results = new DecorationResults();
+        $element = $this->createStub(FormElement::class);
+        $element->method('getLabel')->willReturn('Testing');
+        $element->expects($this->never())->method('getAttributes');
+
+        $this->decorator->decorate($results, $element);
+
+        $this->assertHtml('<label class="form-element-label">Testing</label>', $results);
     }
 }

--- a/tests/FormDecorator/TestDecorator.php
+++ b/tests/FormDecorator/TestDecorator.php
@@ -5,7 +5,6 @@ namespace ipl\Tests\Html\FormDecorator;
 use ipl\Html\Attributes;
 use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\HtmlElement;
 
@@ -19,7 +18,7 @@ class TestDecorator implements Decorator
         return 'Test';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $results->wrap(new HtmlElement('div', new Attributes(['class' => 'test-decorator'])));
     }

--- a/tests/FormDecorator/TestRenderElementDecorator.php
+++ b/tests/FormDecorator/TestRenderElementDecorator.php
@@ -4,7 +4,6 @@ namespace ipl\Tests\Html\FormDecorator;
 
 use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\FormDecorator\DecorationResults;
 
 /**
@@ -17,7 +16,7 @@ class TestRenderElementDecorator implements Decorator
         return 'TestRenderElement';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $results->append($formElement);
     }

--- a/tests/FormDecorator/TestSkipRenderElementDecorator.php
+++ b/tests/FormDecorator/TestSkipRenderElementDecorator.php
@@ -4,7 +4,6 @@ namespace ipl\Tests\Html\FormDecorator;
 
 use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\FormDecorator\DecorationResults;
 
 /**
@@ -17,7 +16,7 @@ class TestSkipRenderElementDecorator implements Decorator
         return 'TestSkipRenderElement';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $results->skipDecorators('TestRenderElement');
         $results->append($formElement);

--- a/tests/FormDecorator/TestWithOptionsDecorator.php
+++ b/tests/FormDecorator/TestWithOptionsDecorator.php
@@ -7,7 +7,6 @@ use ipl\Html\Contract\Decorator;
 use ipl\Html\Contract\DecoratorOptions;
 use ipl\Html\Contract\DecoratorOptionsInterface;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\FormDecorator\DecorationResults;
 use ipl\Html\HtmlElement;
 
@@ -27,7 +26,7 @@ class TestWithOptionsDecorator implements Decorator, DecoratorOptionsInterface
         return 'TestWithOptions';
     }
 
-    public function decorate(DecorationResults $results, FormElement & HtmlElementInterface $formElement): void
+    public function decorate(DecorationResults $results, FormElement $formElement): void
     {
         $results->wrap(new HtmlElement('div', new Attributes(['class' => 'test-with-options-decorator'])));
     }


### PR DESCRIPTION
This was a mis-conception made during #146. `FormElement` may provide `getAttributes()`, but this was only added because of options. Without this, the remaining interface does not describe a HTML element at all. There is even a case, I stumbled over today, where this is alread a thing: `ipl\Html\FormElement\RadioElement` This does not have a tag, and overrides `renderUnwrapped` in order to not having to define one. Though, some of the new decoators also call `getTag()` and so they fail while decorating such an element. This will be tackled in a follow-up PR though.