### PR TITLE
Apply decorators not too late

### DIFF
--- a/src/FormDecoration/DecorationResults.php
+++ b/src/FormDecoration/DecorationResults.php
@@ -11,7 +11,7 @@ use ipl\Html\ValidHtml;
  *
  * @phpstan-type content array<int, ValidHtml|array<int, mixed>>
  */
-class DecorationResults implements ValidHtml
+class DecorationResults
 {
     /** @var content The HTML content */
     protected array $content = [];
@@ -105,20 +105,21 @@ class DecorationResults implements ValidHtml
     }
 
     /**
-     * Render the results
+     * Assemble the results
      *
-     * @return string The rendered HTML content
+     * @return HtmlDocument
      */
-    public function render(): string
+    public function assemble(): HtmlDocument
     {
+        $content = new HtmlDocument();
+
         if (empty($this->content)) {
-            return '';
+            return $content;
         }
 
-        $content = new HtmlDocument();
         $this->resolveContent($content, $this->content);
 
-        return $content->render();
+        return $content;
     }
 
     /**

--- a/src/FormDecoration/DecoratorChain.php
+++ b/src/FormDecoration/DecoratorChain.php
@@ -6,7 +6,6 @@ use InvalidArgumentException;
 use ipl\Html\Contract\FormElementDecoration as Decorator;
 use ipl\Html\Contract\DecoratorOptionsInterface;
 use ipl\Html\Contract\FormElement;
-use ipl\Html\ValidHtml;
 use ipl\Stdlib\Plugins;
 use LogicException;
 use UnexpectedValueException;
@@ -266,11 +265,11 @@ class DecoratorChain
      *
      * @param FormElement $formElement The form element to decorate
      *
-     * @return ValidHtml
+     * @return void
      *
      * @throws LogicException If a decorator wants to skip a decorator that has already been applied
      */
-    public function apply(FormElement $formElement): ValidHtml
+    public function apply(FormElement $formElement): void
     {
         $results = new DecorationResults();
         $appliedDecorators = [];
@@ -294,6 +293,9 @@ class DecoratorChain
             }
         }
 
-        return $results;
+        $result = $results->assemble();
+        if (! $result->isEmpty()) {
+            $formElement->addWrapper($result);
+        }
     }
 }

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -223,14 +223,20 @@ trait FormElements
             }
         }
 
-        $isHidden = $element instanceof HiddenElement || ! $element->getAttributes()->get('hidden')->isEmpty();
         $defaultDecorators = $this->getDefaultElementDecorators();
-        if (! $isHidden && ! empty($defaultDecorators) && ! $this->hasDefaultElementDecorator()) {
+        if (
+            ! empty($defaultDecorators)
+            && ! $this->hasDefaultElementDecorator()
+            && ! $element instanceof HiddenElement
+            && $element->getAttributes()->get('hidden')->isEmpty()
+        ) {
             if ($element instanceof DefaultFormElementDecoration) {
                 $element->setDefaultElementDecorators($defaultDecorators);
             }
 
-            $elementDecoratorChain->addDecorators($defaultDecorators);
+            if (! isset($options['decorators'])) {
+                $elementDecoratorChain->addDecorators($defaultDecorators);
+            }
         }
 
         if ($options !== null) {

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -608,25 +608,4 @@ trait FormElements
     protected function onElementRegistered(FormElement $element)
     {
     }
-
-    /**
-     * Render the element with decorators
-     *
-     * @param FormElement $element
-     *
-     * @return ValidHtml
-     */
-    protected function applyDecoration(FormElement $element): ValidHtml
-    {
-        return $element->getDecorators()->apply($element);
-    }
-
-    public function renderElement(ValidHtml $element): string
-    {
-        if ($element instanceof FormElement && $element->hasDecorators()) {
-            $element = $this->applyDecoration($element);
-        }
-
-        return parent::renderElement($element);
-    }
 }

--- a/src/HtmlDocument.php
+++ b/src/HtmlDocument.php
@@ -324,7 +324,7 @@ class HtmlDocument implements Countable, Wrappable, MutableHtml
                 $element->renderedBy = $this;
             }
 
-            $html[] = $this->renderElement($element);
+            $html[] = $element->render();
 
             if ($element instanceof self) {
                 $element->renderedBy = null;
@@ -332,18 +332,6 @@ class HtmlDocument implements Countable, Wrappable, MutableHtml
         }
 
         return implode($this->contentSeparator, $html);
-    }
-
-    /**
-     * Render the given element to HTML
-     *
-     * @param ValidHtml $element
-     *
-     * @return string The rendered HTML
-     */
-    public function renderElement(ValidHtml $element): string
-    {
-        return $element->render();
     }
 
     public function __clone()

--- a/tests/FormDecorator/DecorationResultsTest.php
+++ b/tests/FormDecorator/DecorationResultsTest.php
@@ -18,7 +18,7 @@ class DecorationResultsTest extends TestCase
 
     public function testEmptyDecorationResultsRenderEmptyString(): void
     {
-        $this->assertSame('', $this->results->render());
+        $this->assertSame('', $this->results->assemble()->render());
     }
 
     public function testMethodSkipDecorators(): void
@@ -47,7 +47,7 @@ class DecorationResultsTest extends TestCase
 <div class="third">Third</div>
 HTML;
 
-        $this->assertHtml($html, $this->results);
+        $this->assertHtml($html, $this->results->assemble());
     }
 
     public function testMethodPrepend(): void
@@ -63,7 +63,7 @@ HTML;
 <div class="third">Third</div>
 HTML;
 
-        $this->assertHtml($html, $this->results);
+        $this->assertHtml($html, $this->results->assemble());
     }
 
     public function testMethodWrap(): void
@@ -81,7 +81,7 @@ HTML;
 </div>
 HTML;
 
-        $this->assertHtml($html, $this->results);
+        $this->assertHtml($html, $this->results->assemble());
     }
 
     public function testAppendAfterWrap(): void
@@ -98,7 +98,7 @@ HTML;
 <div class="second">Second</div>
 HTML;
 
-        $this->assertHtml($html, $this->results);
+        $this->assertHtml($html, $this->results->assemble());
     }
     public function testPrependAfterWrap(): void
     {
@@ -113,7 +113,7 @@ HTML;
   <div class="first">First</div>
 </div>
 HTML;
-        $this->assertHtml($html, $this->results);
+        $this->assertHtml($html, $this->results->assemble());
     }
 
     public function testMixed(): void
@@ -155,7 +155,7 @@ HTML;
 <tag12></tag12>
 <tag14></tag14>
 HTML;
-        $this->assertHtml($html, $this->results);
+        $this->assertHtml($html, $this->results->assemble());
     }
 
     public function testMethodTransformSupportAllCasesAndDoNotThrowAnException(): void
@@ -164,7 +164,7 @@ HTML;
             $this->results->transform($transformation, Html::tag('div'));
         }
 
-        $this->assertNotEmpty($this->results->render());
+        $this->assertNotEmpty($this->results->assemble()->render());
     }
 
     public function testMethodTransformResultsSameAsAppendPrependAndWrap(): void
@@ -172,23 +172,23 @@ HTML;
         $transform = new DecorationResults();
 
         $this->assertSame(
-            $this->results->append(Html::tag('tag1'))->render(),
-            $transform->transform(Transformation::Append, Html::tag('tag1'))->render()
+            $this->results->append(Html::tag('tag1'))->assemble()->render(),
+            $transform->transform(Transformation::Append, Html::tag('tag1'))->assemble()->render()
         );
 
         $this->assertSame(
-            $this->results->wrap(Html::tag('tag2'))->render(),
-            $transform->transform(Transformation::Wrap, Html::tag('tag2'))->render()
+            $this->results->wrap(Html::tag('tag2'))->assemble()->render(),
+            $transform->transform(Transformation::Wrap, Html::tag('tag2'))->assemble()->render()
         );
 
         $this->assertSame(
-            $this->results->prepend(Html::tag('tag3'))->render(),
-            $transform->transform(Transformation::Prepend, Html::tag('tag3'))->render()
+            $this->results->prepend(Html::tag('tag3'))->assemble()->render(),
+            $transform->transform(Transformation::Prepend, Html::tag('tag3'))->assemble()->render()
         );
 
         $this->assertSame(
-            $this->results->append(Html::tag('tag4'))->render(),
-            $transform->transform(Transformation::Append, Html::tag('tag4'))->render()
+            $this->results->append(Html::tag('tag4'))->assemble()->render(),
+            $transform->transform(Transformation::Append, Html::tag('tag4'))->assemble()->render()
         );
     }
 }

--- a/tests/FormDecorator/DecoratorChainTest.php
+++ b/tests/FormDecorator/DecoratorChainTest.php
@@ -198,42 +198,46 @@ class DecoratorChainTest extends TestCase
 
     public function testMethodApplyWithoutADecoratorThatRendersTheElementItself(): void
     {
-        $results = $this->chain
+        $element = new TextElement('element-1');
+        $this->chain
             ->addDecorator('Test')
-            ->apply(new TextElement('element-1'));
+            ->apply($element);
 
         $html = <<<'HTML'
 <div class="test-decorator"></div>
+<input type="text" name="element-1">
 HTML;
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $element);
     }
 
     public function testMethodApplyWithADecoratorThatRendersTheElementItself(): void
     {
-        $results = $this->chain
+        $element = new TextElement('element-1');
+        $this->chain
             ->addDecorators(['TestRenderElement', 'Test'])
-            ->apply(new TextElement('element-1'));
+            ->apply($element);
 
         $html = <<<'HTML'
 <div class="test-decorator">
   <input type="text" name="element-1">
 </div>
 HTML;
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $element);
     }
 
     public function testMethodApplySkipADecoratorThatShouldBeSkipped(): void
     {
-        $results = $this->chain
+        $element = new TextElement('element-1');
+        $this->chain
             ->addDecorators(['TestSkipRenderElement', 'TestRenderElement', 'Test'])
-            ->apply(new TextElement('element-1'));
+            ->apply($element);
 
         $html = <<<'HTML'
 <div class="test-decorator">
   <input type="text" name="element-1">
 </div>
 HTML;
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $element);
     }
 
     public function testMethodApplyThrowsExceptionWhenADecoratorShouldBeSkippedButIsAlreadyApplied(): void

--- a/tests/FormDecorator/DescriptionDecoratorTest.php
+++ b/tests/FormDecorator/DescriptionDecoratorTest.php
@@ -51,7 +51,7 @@ class DescriptionDecoratorTest extends TestCase
         $results = new DecorationResults();
         $this->decorator->decorate($results, new TextElement('test', ['description' => 'Testing']));
 
-        $this->assertHtml('<p class="form-element-description">Testing</p>', $results);
+        $this->assertHtml('<p class="form-element-description">Testing</p>', $results->assemble());
     }
 
     public function testWithDescriptionAndIdAttribute(): void
@@ -62,7 +62,7 @@ class DescriptionDecoratorTest extends TestCase
             new TextElement('test', ['description' => 'Testing', 'id' => 'test-id'])
         );
 
-        $this->assertHtml('<p class="form-element-description" id="desc_test-id">Testing</p>', $results);
+        $this->assertHtml('<p class="form-element-description" id="desc_test-id">Testing</p>', $results->assemble());
     }
 
     public function testWithEmptyDescriptionAttribute(): void
@@ -70,7 +70,7 @@ class DescriptionDecoratorTest extends TestCase
         $results = new DecorationResults();
         $this->decorator->decorate($results, new TextElement('test', ['description' => '']));
 
-        $this->assertHtml('<p class="form-element-description"></p>', $results);
+        $this->assertHtml('<p class="form-element-description"></p>', $results->assemble());
     }
 
     public function testWithoutDescriptionAttribute(): void
@@ -78,7 +78,7 @@ class DescriptionDecoratorTest extends TestCase
         $results = new DecorationResults();
         $this->decorator->decorate($results, new TextElement('test'));
 
-        $this->assertSame('', $results->render());
+        $this->assertSame('', $results->assemble()->render());
     }
 
     public function testFieldsetElementsAreIgnored(): void
@@ -86,7 +86,7 @@ class DescriptionDecoratorTest extends TestCase
         $results = new DecorationResults();
         $this->decorator->decorate($results, new FieldsetElement('test'));
 
-        $this->assertSame('', $results->render());
+        $this->assertSame('', $results->assemble()->render());
     }
 
     public function testNonHtmlFormElementsAreSupported(): void
@@ -98,6 +98,6 @@ class DescriptionDecoratorTest extends TestCase
 
         $this->decorator->decorate($results, $element);
 
-        $this->assertHtml('<p class="form-element-description">Testing</p>', $results);
+        $this->assertHtml('<p class="form-element-description">Testing</p>', $results->assemble());
     }
 }

--- a/tests/FormDecorator/ErrorsDecoratorTest.php
+++ b/tests/FormDecorator/ErrorsDecoratorTest.php
@@ -45,7 +45,7 @@ class ErrorsDecoratorTest extends TestCase
         $results = new DecorationResults();
         $this->decorator->decorate($results, new TextElement('test'));
 
-        $this->assertSame('', $results->render());
+        $this->assertSame('', $results->assemble()->render());
     }
 
     public function testWithErrorMessages(): void
@@ -63,7 +63,7 @@ class ErrorsDecoratorTest extends TestCase
 </ul>
 HTML;
 
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $results->assemble());
     }
 
     public function testNonHtmlFormElementsAreSupported(): void
@@ -81,6 +81,6 @@ HTML;
 </ul>
 HTML;
 
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $results->assemble());
     }
 }

--- a/tests/FormDecorator/FieldsetDecoratorTest.php
+++ b/tests/FormDecorator/FieldsetDecoratorTest.php
@@ -107,7 +107,7 @@ HTML;
         $this->decorator->decorate($results, new FieldsetElement('test', ['label' => 'Testing']));
         $this->decorator->decorate($results, new FieldsetElement('test', ['label' => 'Testing']));
 
-        $this->assertEmpty($results->render());
+        $this->assertEmpty($results->assemble()->render());
     }
 
     public function testNonHtmlFormElementsAreIgnored(): void
@@ -117,6 +117,6 @@ HTML;
 
         $this->decorator->decorate($results, $element);
 
-        $this->assertEmpty($results->render());
+        $this->assertEmpty($results->assemble()->render());
     }
 }

--- a/tests/FormDecorator/FormElementDecorationTest.php
+++ b/tests/FormDecorator/FormElementDecorationTest.php
@@ -36,6 +36,7 @@ HTML;
         $html = <<<'HTML'
 <form method="POST">
   <div class="test-decorator"></div>
+  <input type="text" name="element-1">
 </form>
 HTML;
 

--- a/tests/FormDecorator/HtmlTagDecoratorTest.php
+++ b/tests/FormDecorator/HtmlTagDecoratorTest.php
@@ -63,13 +63,13 @@ class HtmlTagDecoratorTest extends TestCase
             ->setCondition(fn($formElement) => false)
             ->decorate($results, $formElement);
 
-        $this->assertSame('', $results->render());
+        $this->assertSame('', $results->assemble()->render());
 
         $this->decorator
             ->setCondition(fn($formElement) => true)
             ->decorate($results, $formElement);
 
-        $this->assertSame('<div></div>', $results->render());
+        $this->assertSame('<div></div>', $results->assemble()->render());
     }
 
     public function testConditionCallbackThrowsExceptionWhenCallbackFailed(): void
@@ -109,7 +109,7 @@ class HtmlTagDecoratorTest extends TestCase
 </div>
 HTML;
 
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $results->assemble());
     }
 
     public function testMethodDecorateWithPlacementAppend(): void
@@ -126,7 +126,7 @@ HTML;
 <div></div>
 HTML;
 
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $results->assemble());
     }
 
     public function testMethodDecorateWithPlacementPrepend(): void
@@ -143,7 +143,7 @@ HTML;
 <input type="text" name="test">
 HTML;
 
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $results->assemble());
     }
 
     public function testNonHtmlFormElementsAreSupported(): void
@@ -163,6 +163,6 @@ HTML;
 </div>
 HTML;
 
-        $this->assertHtml($html, $results);
+        $this->assertHtml($html, $results->assemble());
     }
 }

--- a/tests/FormDecorator/LabelDecoratorTest.php
+++ b/tests/FormDecorator/LabelDecoratorTest.php
@@ -49,7 +49,7 @@ class LabelDecoratorTest extends TestCase
 
         $this->assertHtml(
             '<label class="form-element-label">Label Here</label>',
-            $results
+            $results->assemble()
         );
     }
 
@@ -63,7 +63,7 @@ class LabelDecoratorTest extends TestCase
 
         $this->assertHtml(
             '<label for="test-id" class="form-element-label">Label Here</label>',
-            $results
+            $results->assemble()
         );
     }
 
@@ -74,7 +74,7 @@ class LabelDecoratorTest extends TestCase
 
         $this->assertHtml(
             '<label class="form-element-label"></label>',
-            $results
+            $results->assemble()
         );
     }
 
@@ -83,7 +83,7 @@ class LabelDecoratorTest extends TestCase
         $results = new DecorationResults();
         $this->decorator->decorate($results, new TextElement('test'));
 
-        $this->assertSame('', $results->render());
+        $this->assertSame('', $results->assemble()->render());
     }
 
     public function testThatSubmitElementsAndFieldsetElementsAreIgnored(): void
@@ -93,7 +93,7 @@ class LabelDecoratorTest extends TestCase
         $this->decorator->decorate($results, new SubmitButtonElement('test'));
         $this->decorator->decorate($results, new SubmitElement('test'));
 
-        $this->assertSame('', $results->render());
+        $this->assertSame('', $results->assemble()->render());
     }
 
     public function testNonHtmlFormElementsAreSupported(): void
@@ -105,6 +105,6 @@ class LabelDecoratorTest extends TestCase
 
         $this->decorator->decorate($results, $element);
 
-        $this->assertHtml('<label class="form-element-label">Testing</label>', $results);
+        $this->assertHtml('<label class="form-element-label">Testing</label>', $results->assemble());
     }
 }

--- a/tests/FormElement/RadioElementTest.php
+++ b/tests/FormElement/RadioElementTest.php
@@ -467,6 +467,7 @@ HTML;
 <p class="form-element-description">Description</p>
 HTML;
 
-        $this->assertHtml($html, $radio->getDecorators()->apply($radio));
+        $radio->getDecorators()->apply($radio);
+        $this->assertHtml($html, $radio);
     }
 }


### PR DESCRIPTION
The new decorators are applied too late. It's not possible to e.g. change elements depending on others nor to prepend or append additional content to their form. When `HtmlDocument::renderElement()` runs, the form's content has already been finalized with the call to `::getContent()` inside `::renderUnwrapped()`.

To change this, decorators are now applied after form assembly. Application of decorators is now also done differently as they're registered as wrappers again. But this time not in a way that anyone can or should assume their existence. Once a form has been assembled, the decoration results are *added* as wrapper. This means that any other wrappers the elements already have, will be decorated as well.

* Elements will always be rendered, even without a decorator that assigns them a position (default behavior of wrappers)
* To decorate an element, **`FormElements::decorate()` must be used**, but that should not be a problem as it already used to be like this.
  At least for *new* default decorators. *Legacy* custom decorators didn't require this, but anyone who's not using `addElement` always had to replicate it's behavior so this is fine to me

requires #162 