### PR TITLE
Form and form elements emit events

### DIFF
--- a/src/Contract/Form.php
+++ b/src/Contract/Form.php
@@ -2,9 +2,10 @@
 
 namespace ipl\Html\Contract;
 
+use Evenement\EventEmitterInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-interface Form
+interface Form extends EventEmitterInterface
 {
     /** @var string Event emitted when the form is associated with a request but is not sent */
     public const ON_REQUEST = 'request';

--- a/src/Contract/FormElements.php
+++ b/src/Contract/FormElements.php
@@ -2,9 +2,10 @@
 
 namespace ipl\Html\Contract;
 
+use Evenement\EventEmitterInterface;
 use InvalidArgumentException;
 
-interface FormElements
+interface FormElements extends EventEmitterInterface
 {
     /** @var string Event emitted when an element is registered */
     public const ON_ELEMENT_REGISTERED = 'elementRegistered';


### PR DESCRIPTION
So let them extend `Evenement\EventEmitterInterface`, and anyone relying on either interface is *actually* capable of listening to their events.