### PR TITLE
DecoratorChain: Support class paths in `createDecorator`

### DIFF
--- a/tests/FormDecorator/DecoratorChainTest.php
+++ b/tests/FormDecorator/DecoratorChainTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Html\FormDecorator;
 use InvalidArgumentException;
 use ipl\Html\FormDecoration\DecoratorChain;
 use ipl\Html\Contract\FormElementDecoration;
+use ipl\Html\HtmlDocument;
 use ipl\Tests\Html\TestCase;
 
 class DecoratorChainTest extends TestCase
@@ -104,11 +105,23 @@ class DecoratorChainTest extends TestCase
         $this->chain->addDecorator(new TestDecorator(), ['optionKey1' => 'optionValue1']);
     }
 
+    public function testMethodAddDecoratorThrowsExceptionWhenInvalidClassPathIsPassed(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Invalid decorator class 'ipl\Html\HtmlDocument'."
+            ." decorator must be an instance of ipl\Html\Contract\FormElementDecoration"
+        );
+
+        $this->chain->addDecorator(HtmlDocument::class);
+    }
+
     public function testMethodAddDecoratorsWithValidArrayAsParam(): void
     {
         $decoratorFormats = [
             'TestWithOptions',
             new TestWithOptionsDecorator(),
+            TestWithOptionsDecorator::class,
             'TestWithOptions' => ['optionKey1' => 'optionValue1', 'options' => ['optionKey2' => 'optionValue2']],
             ['name' => 'TestWithOptions', 'options' => ['optionKey2' => 'optionValue2']]
         ];


### PR DESCRIPTION
Allows to use a specific decorator, bypassing a loader that would load another decorator when only using the name.

Not used right now, but I had a use-case a few days ago which I dismissed but this feature is still a good idea I think.