### PR TITLE
DecoratorChain: Allow to replace specific decorators

### DIFF
--- a/doc/45-Form-Decorators.md
+++ b/doc/45-Form-Decorators.md
@@ -11,6 +11,13 @@ rendering order.
 The decoration of an element is triggered only when the form is rendered. This ensures that decoration remains isolated
 and does not produce unexpected side effects.
 
+> NOTE: Decorators are registered with unique identifiers to enable easy replacement. If the decorator is provided as a
+> string and no identifier is given, the decorator name is used as a fallback. In all other cases, an identifier must be
+> specified explicitly.
+
+It is recommended to use the decorator name or its purpose as the identifier, for example, 'container' for an 'HtmlTag'
+decorator that wraps content.
+
 Example usage
 -------------
 Let's decorate a form element using the built-in `Label` and `Description` decorators.

--- a/doc/45-Form-Decorators.md
+++ b/doc/45-Form-Decorators.md
@@ -77,14 +77,14 @@ array form. For the full list of supported options, see the respective classes u
 
 ```php
 $form->setDefaultElementDecorators([
-    [
+    'label' => [
         'name' => 'Label',
         'options' => [
             'class' => ['form-element-label', 'text-bold']
         ],
     ],
     'RenderElement',
-    [
+    'description' => [
         'name' => 'Description',
         'options' => [
             'class' => 'help-text'
@@ -121,7 +121,7 @@ $form = (new Form())
         'Label',
         'RenderElement',
         'Description',
-        [
+        'group' => [
             'name' => 'HtmlTag',
             'options' => [
                 'tag'       => 'div',
@@ -152,7 +152,7 @@ $form->setDefaultElementDecorators([
     'Label',
     'RenderElement',
     'Description',
-    [
+    'separator' => [
         'name' => 'HtmlTag',
         'options' => [
             'tag'               => 'span',
@@ -183,7 +183,7 @@ $form->setDefaultElementDecorators([
     'Label',
     'RenderElement',
     'Description',
-    [
+    'before' => [
         'name' => 'HtmlTag',
         'options' => [
             'tag'               => 'span',
@@ -214,7 +214,7 @@ $form->setDefaultElementDecorators([
     'Label',
     'RenderElement',
     'Description',
-    [
+    'required' => [
         'name' => 'HtmlTag',
         'options' => [
             'tag'               => 'div',

--- a/src/FormDecoration/DecoratorChain.php
+++ b/src/FormDecoration/DecoratorChain.php
@@ -132,45 +132,50 @@ class DecoratorChain implements IteratorAggregate
      *
      * The order of the decorators is important, as it determines the rendering order.
      *
+     * > NOTE: Decorators are registered with unique identifiers to enable easy replacement. If the decorator is
+     * provided as a string and no identifier is given, the decorator name is used as a fallback. In all other cases,
+     * an identifier must be specified explicitly.
+     *
+     *  *It is recommended to use the decorator name or its purpose as the identifier, for example, 'container' for an
+     * 'HtmlTag' decorator that wraps content.*
+     *
      *   *The following array formats are supported:*
      *
      * ```
-     * // When no options are required or defaults are sufficient
+     * // (1) When no options are required or defaults are sufficient
      * $decorators = [
      *     'Label',
      *     'Description'
      * ];
      *
-     * // Custom identifiers
-     * $decorators = [
-     *     'label' => 'Label',
-     *     'description' => 'Description'
-     * ];
+     * // For the array above, the identifiers are 'Label' and 'Description'.
      *
-     * // Override default options
+     *  // (2) Use Custom identifiers
+     *  $decorators = [
+     *     'your-custom-identifier' => 'your-custom-decorator',
+     *  ];
      *
-     * // key: decorator identifier, value: name and options
+     * // NOTE: For the following formats, identifiers MUST be defined manually.
+     *
+     * // (3) Override default options, key: decorator identifier, value: name and options
      * $decorators = [
+     *     'Label' => 'Label',
      *     'container' => [
-     *          'name' => 'HtmlTag',
-     *          'options' => ['tag' => 'span', 'placement' => 'append']
-     *      ],
-     *     'label' => [
-     *         'name' => 'Label',
-     *         'options' => ['class' => 'element-label']
-     *     ]
+     *          'name'      => 'HtmlTag',
+     *          'options'   => ['tag' => 'div']
+     *      ]
      * ];
      *
-     * // or add Decorator instances
+     * // (4) Add Decorator instances
      * $decorators = [
-     *     'container' => (new HtmlTagDecorator())->getAttributes()->add(['tag' => 'span', 'placement' => 'append']),
-     *     'label' => (new LabelDecorator())->getAttributes()->add(['class' => 'element-label'])
+     *     'Label'      => new LabelDecorator(),
+     *     'container'  => (new HtmlTagDecorator())->setTag('div')->setAttrs(['class' => 'container'])
      * ];
      *
-     * // Class paths are also supported
+     * // (5) Class paths are also supported
      * $decorators = [
-     *     'label' => LabelDecorator::class,
-     *     'container' => ['name' => HtmlTagDecorator::class, ['tag' => 'span', 'placement' => 'append']]
+     *     'Label'      => LabelDecorator::class,
+     *     'container'  => ['name' => HtmlTagDecorator::class, 'options' => ['tag' => 'div']]
      * ];
      * ```
      *
@@ -250,7 +255,7 @@ class DecoratorChain implements IteratorAggregate
             } else {
                 throw new InvalidArgumentException(sprintf(
                     "Invalid type for identifier %s, expected an array,"
-                    . "a string or an instance of %s, got '%s' instead",
+                    . " a string or an instance of %s, got '%s' instead",
                     $identifier,
                     $this->decoratorType,
                     get_php_type($decoratorOptions)

--- a/src/FormDecoration/DecoratorChain.php
+++ b/src/FormDecoration/DecoratorChain.php
@@ -8,6 +8,7 @@ use ipl\Html\Contract\DecoratorOptionsInterface;
 use ipl\Stdlib\Plugins;
 use IteratorAggregate;
 use UnexpectedValueException;
+use ValueError;
 
 use function ipl\Stdlib\get_php_type;
 
@@ -30,7 +31,7 @@ class DecoratorChain implements IteratorAggregate
     /** @var class-string<TDecorator> The type of decorator to accept */
     private string $decoratorType;
 
-    /** @var TDecorator[] All registered decorators */
+    /** @var array<string, TDecorator> All registered decorators */
     private array $decorators = [];
 
     /**
@@ -61,18 +62,37 @@ class DecoratorChain implements IteratorAggregate
     }
 
     /**
-     * Add a decorator to the chain.
+     * Get whether the chain has a decorator with the given identifier
      *
+     * @param string $identifier
+     *
+     * @return bool
+     */
+    public function hasDecorator(string $identifier): bool
+    {
+        return isset($this->decorators[$identifier]);
+    }
+
+    /**
+     * Add a decorator to the chain
+     *
+     * @param string                 $identifier
      * @param TDecorator|Ident       $decorator
-     * @param decoratorOptionsFormat $options Only allowed if parameter 1 is a string
+     * @param decoratorOptionsFormat $options Only allowed if parameter 2 is a string
      *
      * @return $this
      *
+     * @throws ValueError If the decorator with the given identifier already exists
      * @throws InvalidArgumentException If the decorator specification is invalid
      */
-    public function addDecorator(object|string $decorator, array $options = []): static
+    public function addDecorator(string $identifier, object|string $decorator, array $options = []): static
     {
-        if (! empty($options) && ! is_string($decorator)) {
+        if (isset($this->decorators[$identifier])) {
+            throw new ValueError(sprintf(
+                'Decorator with identifier "%s" already exists. Use replaceDecorator() to replace it.',
+                $identifier
+            ));
+        } elseif (! empty($options) && ! is_string($decorator)) {
             throw new InvalidArgumentException('No options are allowed with parameter 1 of type Decorator');
         }
 
@@ -86,9 +106,25 @@ class DecoratorChain implements IteratorAggregate
             ));
         }
 
-        $this->decorators[] = $decorator;
+        $this->decorators[$identifier] = $decorator;
 
         return $this;
+    }
+
+    /**
+     * Replace a decorator in the chain with a new one
+     *
+     * @param string                 $identifier
+     * @param TDecorator|Ident       $decorator
+     * @param decoratorOptionsFormat $options Only allowed if parameter 2 is a string
+     *
+     * @return $this
+     */
+    public function replaceDecorator(string $identifier, object|string $decorator, array $options = []): static
+    {
+        $this->decorators[$identifier] = null; // Preserve the placement of the previous decorator
+
+        return $this->addDecorator($identifier, $decorator, $options);
     }
 
     /**
@@ -101,34 +137,40 @@ class DecoratorChain implements IteratorAggregate
      * ```
      * // When no options are required or defaults are sufficient
      * $decorators = [
-     *     'HtmlTag',
-     *     'Label'
+     *     'Label',
+     *     'Description'
      * ];
      *
-     * // Override default options by defining the option key and value
-     *
-     * // key: decorator name, value: options
+     * // Custom identifiers
      * $decorators = [
-     *     'HtmlTag' => ['tag' => 'span', 'placement' => 'append'],
-     *     'Label' => ['class' => 'element-label']
+     *     'label' => 'Label',
+     *     'description' => 'Description'
      * ];
      *
-     * // or define the `name` and `options` key
+     * // Override default options
+     *
+     * // key: decorator identifier, value: name and options
      * $decorators = [
-     *     ['name' => 'HtmlTag', 'options' => ['tag' => 'span', 'placement' => 'append']],
-     *     ['name' => 'Label', 'options' => ['class' => 'element-label']]
+     *     'container' => [
+     *          'name' => 'HtmlTag',
+     *          'options' => ['tag' => 'span', 'placement' => 'append']
+     *      ],
+     *     'label' => [
+     *         'name' => 'Label',
+     *         'options' => ['class' => 'element-label']
+     *     ]
      * ];
      *
      * // or add Decorator instances
      * $decorators = [
-     *     (new HtmlTagDecorator())->getAttributes()->add(['tag' => 'span', 'placement' => 'append']),
-     *     (new LabelDecorator())->getAttributes()->add(['class' => 'element-label'])
+     *     'container' => (new HtmlTagDecorator())->getAttributes()->add(['tag' => 'span', 'placement' => 'append']),
+     *     'label' => (new LabelDecorator())->getAttributes()->add(['class' => 'element-label'])
      * ];
      *
      * // Class paths are also supported
      * $decorators = [
-     *     LabelDecorator::class,
-     *     ['name' => HtmlTagDecorator::class, ['tag' => 'span', 'placement' => 'append']]
+     *     'label' => LabelDecorator::class,
+     *     'container' => ['name' => HtmlTagDecorator::class, ['tag' => 'span', 'placement' => 'append']]
      * ];
      * ```
      *
@@ -141,66 +183,88 @@ class DecoratorChain implements IteratorAggregate
     public function addDecorators(DecoratorChain|array $decorators): static
     {
         if ($decorators instanceof static) {
-            foreach ($decorators->decorators as $decorator) {
-                $this->addDecorator($decorator);
+            foreach ($decorators->decorators as $identifier => $decorator) {
+                $this->addDecorator($identifier, $decorator);
             }
 
             return $this;
         }
 
         foreach ($decorators as $decoratorName => $decoratorOptions) {
-            $position = $decoratorName;
-            if (is_int($decoratorName)) {
-                if (is_array($decoratorOptions)) {
-                    if (! isset($decoratorOptions['name'])) {
-                        throw new InvalidArgumentException("Key 'name' is missing");
-                    }
-
-                    $decoratorName = $decoratorOptions['name'];
-                    unset($decoratorOptions['name']);
-
-                    $options = [];
-                    if (isset($decoratorOptions['options'])) {
-                        $options = $decoratorOptions['options'];
-
-                        unset($decoratorOptions['options']);
-                    }
-
-                    if (! empty($decoratorOptions)) {
-                        throw new InvalidArgumentException(
-                            sprintf(
-                                "No other keys except 'name' and 'options' are allowed, got '%s'",
-                                implode("', '", array_keys($decoratorOptions))
-                            )
-                        );
-                    }
-
-                    $decoratorOptions = $options;
-                } else {
-                    $decoratorName = $decoratorOptions;
-                    $decoratorOptions = [];
+            $identifier = $decoratorName;
+            if (is_int($identifier)) {
+                if (! is_string($decoratorOptions)) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Unexpected type at position %d, string expected, got %s instead',
+                        $identifier,
+                        get_php_type($decoratorOptions)
+                    ));
+                } elseif (class_exists($decoratorOptions)) {
+                    throw new InvalidArgumentException(sprintf(
+                        'Unexpected type at position %d, string expected, got class %s instead',
+                        $identifier,
+                        $decoratorOptions
+                    ));
                 }
-            }
 
-            if (! is_array($decoratorOptions)) {
-                throw new InvalidArgumentException(sprintf(
-                    "The key must be a decorator name and value must be an array of options, got value of type"
-                    . " '%s' for key '%s'",
-                    get_php_type($decoratorOptions),
-                    $decoratorName,
-                ));
-            }
+                $decoratorName = $decoratorOptions;
+                $identifier = $decoratorName;
+                $decoratorOptions = [];
+            } elseif (is_string($decoratorOptions) || $decoratorOptions instanceof $this->decoratorType) {
+                $decoratorName = $decoratorOptions;
+                $decoratorOptions = [];
+            } elseif (is_array($decoratorOptions)) {
+                if (! isset($decoratorOptions['name'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        "Invalid decorator '%s'. Key 'name' is missing",
+                        $identifier
+                    ));
+                } elseif (! is_string($decoratorOptions['name'])) {
+                    throw new InvalidArgumentException(sprintf(
+                        "Invalid decorator '%s'. Key 'name' must be a string, got %s instead",
+                        $identifier,
+                        get_php_type($decoratorOptions['name'])
+                    ));
+                }
 
-            if (! is_string($decoratorName) && ! $decoratorName instanceof $this->decoratorType) {
+                $decoratorName = $decoratorOptions['name'];
+                unset($decoratorOptions['name']);
+
+                $options = [];
+                if (isset($decoratorOptions['options'])) {
+                    $options = $decoratorOptions['options'];
+
+                    unset($decoratorOptions['options']);
+                }
+
+                if (! empty($decoratorOptions)) {
+                    throw new InvalidArgumentException(
+                        sprintf(
+                            "No other keys except 'name' and 'options' are allowed, got '%s'",
+                            implode("', '", array_keys($decoratorOptions))
+                        )
+                    );
+                }
+
+                $decoratorOptions = $options;
+            } else {
                 throw new InvalidArgumentException(sprintf(
-                    'Expects array value at position %d to be a string or an instance of %s, got %s instead',
-                    $position,
+                    "Invalid type for identifier %s, expected an array,"
+                    . "a string or an instance of %s, got '%s' instead",
+                    $identifier,
                     $this->decoratorType,
-                    get_php_type($decoratorName)
+                    get_php_type($decoratorOptions)
                 ));
             }
 
-            $this->addDecorator($decoratorName, $decoratorOptions);
+            if ($this->hasDecorator($identifier)) {
+                throw new InvalidArgumentException(sprintf(
+                    "Decorator with identifier '%s' already exists. Duplicate identifiers are not allowed.",
+                    $identifier
+                ));
+            }
+
+            $this->addDecorator($identifier, $decoratorName, $decoratorOptions);
         }
 
         return $this;

--- a/src/FormDecoration/DecoratorChain.php
+++ b/src/FormDecoration/DecoratorChain.php
@@ -78,7 +78,7 @@ class DecoratorChain implements IteratorAggregate
      *
      * @param string                 $identifier
      * @param TDecorator|Ident       $decorator
-     * @param decoratorOptionsFormat $options Only allowed if parameter 2 is a string
+     * @param decoratorOptionsFormat $options Only allowed if parameter #2 is a string
      *
      * @return $this
      *
@@ -93,14 +93,14 @@ class DecoratorChain implements IteratorAggregate
                 $identifier
             ));
         } elseif (! empty($options) && ! is_string($decorator)) {
-            throw new InvalidArgumentException('No options are allowed with parameter 1 of type Decorator');
+            throw new InvalidArgumentException('No options are allowed with parameter #2 of type Decorator');
         }
 
         if (is_string($decorator)) {
             $decorator = $this->createDecorator($decorator, $options);
         } elseif (! $decorator instanceof $this->decoratorType) {
             throw new InvalidArgumentException(sprintf(
-                'Expects parameter 1 to be a string or an instance of %s, got %s instead',
+                'Expects parameter #2 to be a string or an instance of %s, got %s instead',
                 $this->decoratorType,
                 get_php_type($decorator)
             ));
@@ -116,7 +116,7 @@ class DecoratorChain implements IteratorAggregate
      *
      * @param string                 $identifier
      * @param TDecorator|Ident       $decorator
-     * @param decoratorOptionsFormat $options Only allowed if parameter 2 is a string
+     * @param decoratorOptionsFormat $options Only allowed if parameter #2 is a string
      *
      * @return $this
      */
@@ -200,13 +200,15 @@ class DecoratorChain implements IteratorAggregate
             if (is_int($identifier)) {
                 if (! is_string($decoratorOptions)) {
                     throw new InvalidArgumentException(sprintf(
-                        'Unexpected type at position %d, string expected, got %s instead',
+                        'Unexpected type at position %d, string expected, got %s instead.'
+                        . ' Either provide an $identifier (string) as the key, or ensure the value is of type string',
                         $identifier,
                         get_php_type($decoratorOptions)
                     ));
                 } elseif (class_exists($decoratorOptions)) {
                     throw new InvalidArgumentException(sprintf(
-                        'Unexpected type at position %d, string expected, got class %s instead',
+                        'Unexpected type at position %d, string expected, got class %s instead.'
+                        . ' Either provide an $identifier (string) as the key, or ensure the value is of type string',
                         $identifier,
                         $decoratorOptions
                     ));
@@ -226,7 +228,7 @@ class DecoratorChain implements IteratorAggregate
                     ));
                 } elseif (! is_string($decoratorOptions['name'])) {
                     throw new InvalidArgumentException(sprintf(
-                        "Invalid decorator '%s'. Key 'name' must be a string, got %s instead",
+                        "Invalid decorator '%s'. Value of the 'name' key must be a string, got %s instead",
                         $identifier,
                         get_php_type($decoratorOptions['name'])
                     ));
@@ -254,8 +256,8 @@ class DecoratorChain implements IteratorAggregate
                 $decoratorOptions = $options;
             } else {
                 throw new InvalidArgumentException(sprintf(
-                    "Invalid type for identifier %s, expected an array,"
-                    . " a string or an instance of %s, got '%s' instead",
+                    "Invalid type for identifier '%s', expected an array,"
+                    . " a string or an instance of %s, got %s instead",
                     $identifier,
                     $this->decoratorType,
                     get_php_type($decoratorOptions)

--- a/tests/FormDecorator/DecoratorChainTest.php
+++ b/tests/FormDecorator/DecoratorChainTest.php
@@ -7,6 +7,7 @@ use ipl\Html\FormDecoration\DecoratorChain;
 use ipl\Html\Contract\FormElementDecoration;
 use ipl\Html\HtmlDocument;
 use ipl\Tests\Html\TestCase;
+use ValueError;
 
 class DecoratorChainTest extends TestCase
 {
@@ -20,11 +21,11 @@ class DecoratorChainTest extends TestCase
 
     public function testMethodAddDecorator(): void
     {
-        $this->chain->addDecorator('Test');
+        $this->chain->addDecorator('test', 'Test');
         $decorators = iterator_to_array($this->chain);
 
         $this->assertNotEmpty($decorators);
-        $this->assertInstanceOf(TestDecorator::class, $decorators[0]);;
+        $this->assertInstanceOf(TestDecorator::class, $decorators[0]);
     }
 
     /**
@@ -33,8 +34,8 @@ class DecoratorChainTest extends TestCase
     public function testMethodClearDecorators(): void
     {
          $this->chain
-            ->addDecorator('Test')
-            ->addDecorator('TestWithOptions');
+            ->addDecorator('test', 'Test')
+            ->addDecorator('test2', 'TestWithOptions');
 
         $this->assertCount(2, iterator_to_array($this->chain));
 
@@ -51,8 +52,8 @@ class DecoratorChainTest extends TestCase
         $this->assertFalse($this->chain->hasDecorators());
 
         $this->chain
-            ->addDecorator('Test')
-            ->addDecorator('TestWithOptions');
+            ->addDecorator('test1', 'Test')
+            ->addDecorator('test2', 'TestWithOptions');
 
         $this->assertTrue($this->chain->hasDecorators());
         $this->assertFalse($this->chain->clearDecorators()->hasDecorators());
@@ -63,14 +64,14 @@ class DecoratorChainTest extends TestCase
      */
     public function testMethodAddDecoratorWithAllowedParamFormats(): void
     {
-        $this->chain->addDecorator('TestWithOptions');
+        $this->chain->addDecorator('test', 'TestWithOptions');
         $decorators = iterator_to_array($this->chain);
         $this->assertCount(1, $decorators);
         $decorator = $decorators[0];
         $this->assertInstanceOf(TestWithOptionsDecorator::class, $decorator);
         $this->chain->clearDecorators();
 
-        $this->chain->addDecorator(new TestWithOptionsDecorator());
+        $this->chain->addDecorator('test', new TestWithOptionsDecorator());
         $decorators = iterator_to_array($this->chain);
         $this->assertCount(1, $decorators);
         $decorator = $decorators[0];
@@ -81,7 +82,7 @@ class DecoratorChainTest extends TestCase
             'attrs' => ['setter' => 'setter'], // set via setAttrs(), returned values of getAttrs() contains it
             'not-setter' => 'not-setter' // added as attribute, returned values of getAttrs() does not contain it
         ];
-        $this->chain->addDecorator('TestWithOptions', $options);
+        $this->chain->addDecorator('test', 'TestWithOptions', $options);
         $decorators = iterator_to_array($this->chain);
         $this->assertCount(1, $decorators);
         $decorator = $decorators[0];
@@ -95,14 +96,14 @@ class DecoratorChainTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Can't load decorator 'invalid'. decorator unknown");
 
-        $this->chain->addDecorator('invalid');
+        $this->chain->addDecorator('unknown', 'invalid');
     }
 
     public function testMethodAddDecoratorThrowsExceptionWhenDecoratorInstanceWithOptionsIsPassed(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('No options are allowed with parameter 1 of type Decorator');
-        $this->chain->addDecorator(new TestDecorator(), ['optionKey1' => 'optionValue1']);
+        $this->chain->addDecorator('test', new TestDecorator(), ['optionKey1' => 'optionValue1']);
     }
 
     public function testMethodAddDecoratorThrowsExceptionWhenInvalidClassPathIsPassed(): void
@@ -113,17 +114,19 @@ class DecoratorChainTest extends TestCase
             ." decorator must be an instance of ipl\Html\Contract\FormElementDecoration"
         );
 
-        $this->chain->addDecorator(HtmlDocument::class);
+        $this->chain->addDecorator('document', HtmlDocument::class);
     }
 
     public function testMethodAddDecoratorsWithValidArrayAsParam(): void
     {
         $decoratorFormats = [
             'TestWithOptions',
-            new TestWithOptionsDecorator(),
-            TestWithOptionsDecorator::class,
-            'TestWithOptions' => ['optionKey1' => 'optionValue1', 'options' => ['optionKey2' => 'optionValue2']],
-            ['name' => 'TestWithOptions', 'options' => ['optionKey2' => 'optionValue2']]
+            'test' => new TestWithOptionsDecorator(),
+            'test2' => TestWithOptionsDecorator::class,
+            'test3' => [
+                'name' => 'TestWithOptions',
+                'options' => ['optionKey1' => 'optionValue1', 'options' => ['optionKey2' => 'optionValue2']]
+            ]
         ];
 
         $this->assertCount(count($decoratorFormats), iterator_to_array($this->chain->addDecorators($decoratorFormats)));
@@ -136,9 +139,11 @@ class DecoratorChainTest extends TestCase
     {
         $decoratorFormats = [
             'TestWithOptions',
-            new TestWithOptionsDecorator(),
-            'TestWithOptions' => ['optionKey1' => 'optionValue1'],
-            ['name' => 'TestWithOptions', 'options' => ['optionKey2' => 'optionValue2']]
+            'test1' => new TestWithOptionsDecorator(),
+            'test2' => [
+                'name' => 'TestWithOptions',
+                'options' => ['optionKey1' => 'optionValue1']
+            ]
         ];
 
         $chain = (new DecoratorChain(FormElementDecoration::class))
@@ -168,8 +173,8 @@ class DecoratorChainTest extends TestCase
         $this->chain->clearDecorators();
 
         $decoratorFormats = [
-            ['name' => 'TestWithOptions'],
-            ['name' => 'Test']
+            'test1' => ['name' => 'TestWithOptions'],
+            'test2' => ['name' => 'Test']
         ];
         $decorators = iterator_to_array($this->chain->addDecorators($decoratorFormats));
         $this->assertCount(count($decoratorFormats), $decorators);
@@ -182,7 +187,7 @@ class DecoratorChainTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage("Key 'name' is missing");
 
-        $this->chain->addDecorators([['TestWithOptions']]);
+        $this->chain->addDecorators(['test' => ['TestWithOptions']]);
     }
 
     public function testAddDecoratorsThrowsExceptionWhenADecoratorAsNonAssociativeArrayDefinesUnknownKeys(): void
@@ -192,7 +197,7 @@ class DecoratorChainTest extends TestCase
 
         $this->chain
             ->addDecorators([
-                ['name' => 'TestWithOptions', 'unknownKey' => 'unknownValue', 5 => 'also unknown'],
+                'test' => ['name' => 'TestWithOptions', 'unknownKey' => 'unknownValue', 5 => 'also unknown'],
             ]);
     }
 
@@ -200,8 +205,7 @@ class DecoratorChainTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            "The key must be a decorator name and value must be an array of options, got value of type"
-            . " 'string' for key 'something'",
+            "Can't load decorator 'this is string instead of array'. decorator unknown"
         );
 
         $this->chain->addDecorators(['something' => 'this is string instead of array']);
@@ -211,10 +215,80 @@ class DecoratorChainTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage(
-            'Expects array value at position 0 to be a string or an instance of ipl\Html\Contract\FormElementDecoration,'
-            . ' got ipl\Html\FormDecoration\DecoratorChain instead'
+            'Unexpected type at position 0, string expected, got ipl\Html\FormDecoration\DecoratorChain instead'
         );
 
         $this->chain->addDecorators([$this->chain]);
+    }
+
+    public function testAddDecoratorsDetectsDuplicateIdentifiers(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            "Decorator with identifier 'Test' already exists. Duplicate identifiers are not allowed."
+        );
+
+        $this->chain->addDecorators([
+            'Test' => 'TestWithOptions',
+            'Test'
+        ]);
+    }
+
+    public function testHasDecoratorReturnsFalseWhenNoDecoratorsAreAdded(): void
+    {
+        $this->assertFalse($this->chain->hasDecorator('test'));
+    }
+
+    public function testHasDecoratorReturnsTrueWhenDecoratorIsAdded(): void
+    {
+        $this->chain->addDecorator('test', 'Test');
+        $this->assertTrue($this->chain->hasDecorator('test'));
+    }
+
+    public function testHasDecoratorReturnsFalseWhenDecoratorIsNotAdded(): void
+    {
+        $this->chain->addDecorator('test1', 'Test');
+        $this->assertFalse($this->chain->hasDecorator('test2'));
+    }
+
+    public function testAddDecoratorThrowsExceptionWhenDecoratorIsAlreadyAdded(): void
+    {
+        $this->expectException(ValueError::class);
+        $this->expectExceptionMessage(
+            'Decorator with identifier "test" already exists. Use replaceDecorator() to replace it.'
+        );
+
+        $this->chain
+            ->addDecorator('test', 'Test')
+            ->addDecorator('test', 'Test');
+    }
+
+    public function testReplaceDecoratorWorksEvenIfThereIsNoDecoratorYet(): void
+    {
+        $this->chain->replaceDecorator('test', 'Test');
+        $this->assertTrue($this->chain->hasDecorator('test'));
+    }
+
+    public function testReplaceDecoratorWorksWhenDecoratorIsAlreadyAdded(): void
+    {
+        $this->chain
+            ->addDecorator('test', 'Test')
+            ->replaceDecorator('test', 'TestWithOptions');
+
+        $decorators = iterator_to_array($this->chain);
+        $this->assertCount(1, $decorators);
+        $this->assertInstanceOf(TestWithOptionsDecorator::class, $decorators[0]);
+    }
+
+    public function testReplaceDecoratorPreservesDecoratorOrder(): void
+    {
+        $this->chain
+            ->addDecorator('test1', 'Test')
+            ->addDecorator('test2', 'TestWithOptions')
+            ->replaceDecorator('test1', 'TestRenderElement');
+
+        $decorators = iterator_to_array($this->chain);
+        $this->assertInstanceOf(TestRenderElementDecorator::class, $decorators[0]);
+        $this->assertInstanceOf(TestWithOptionsDecorator::class, $decorators[1]);
     }
 }

--- a/tests/FormDecorator/FormDecorationTest.php
+++ b/tests/FormDecorator/FormDecorationTest.php
@@ -42,6 +42,7 @@ class FormDecorationTest extends TestCase
         $form = new \ipl\Html\Form();
         $form->addHtml(Html::tag('div', ['class' => 'test-html']));
         $form->getDecorators()->addDecorator(
+            'test',
             $this->createFormDecorator()
                 ->setTransformation(Transformation::Prepend)
         );
@@ -57,11 +58,12 @@ class FormDecorationTest extends TestCase
         $form = new \ipl\Html\Form();
         $form->addElementDecoratorLoaderPaths([[__NAMESPACE__, 'Decorator']]);
         $form->getDecorators()->addDecorator(
+            'test',
             $this->createFormDecorator()
                 ->setTransformation(Transformation::Prepend)
         );
         $form->addElement('text', 'test', [
-            'decorators' => ['TestRenderElement', $this->createFormDecorator()]
+            'decorators' => ['TestRenderElement', 'test' => $this->createFormDecorator()]
         ]);
 
         $html = <<<'HTML'
@@ -81,6 +83,7 @@ HTML;
         $form = new \ipl\Html\Form();
         $form->addHtml(Html::tag('div', ['class' => 'test-html']));
         $form->getDecorators()->addDecorator(
+            'test',
             $this->createFormDecorator()
                 ->setTransformation(Transformation::Append)
         );
@@ -96,6 +99,7 @@ HTML;
         $form = new \ipl\Html\Form();
         $form->addHtml(Html::tag('div', ['class' => 'test-html']));
         $form->getDecorators()->addDecorator(
+            'test',
             $this->createFormDecorator()
                 ->setTransformation(Transformation::Wrap)
         );
@@ -117,9 +121,9 @@ HTML;
         $singleton->expects($this->once())->method('decorateFormElement');
 
         $form = new \ipl\Html\Form();
-        $form->getDecorators()->addDecorator($singleton);
+        $form->getDecorators()->addDecorator('test', $singleton);
         $form->addElement('text', 'test', [
-            'decorators' => [$singleton]
+            'decorators' => ['test' => $singleton]
         ]);
 
         $form->render();
@@ -129,6 +133,7 @@ HTML;
     {
         $form = new \ipl\Html\Form();
         $form->getDecorators()->addDecorator(
+            'test',
             $this->createFormDecorator()
                 ->setTransformation(Transformation::Append)
         );
@@ -165,9 +170,9 @@ HTML;
         };
 
         $form = new \ipl\Html\Form();
-        $form->getDecorators()->addDecorator($decorator);
+        $form->getDecorators()->addDecorator('test', $decorator);
         $form->addElement('text', 'test', [
-            'decorators' => [$decorator]
+            'decorators' => ['test' => $decorator]
         ]);
 
         $form->render();


### PR DESCRIPTION
For this all decorators require an identifier now. This is a breaking change compared to the current state. In the past using Zend form, we often copied the default list of decorators just to change a single decorator. Though, changes to the default decorators were never applied by forms overriding them, so this functionality in the new implementation should provide more flexibility in this regard.