### PR TITLE
Support PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "ipl/stdlib": ">=0.12.0",
     "ipl/validator": ">=0.5.0",
     "psr/http-message": "^1.1",
-    "guzzlehttp/psr7": "^2.5"
+    "guzzlehttp/psr7": "^2.8"
   },
   "require-dev": {
     "ext-dom": "*",

--- a/src/Attributes.php
+++ b/src/Attributes.php
@@ -38,9 +38,9 @@ class Attributes implements ArrayAccess, IteratorAggregate
     /**
      * Create new HTML attributes
      *
-     * @param AttributesType $attributes
+     * @param ?AttributesType $attributes
      */
-    public function __construct(array $attributes = null)
+    public function __construct(?array $attributes = null)
     {
         if (empty($attributes)) {
             return;
@@ -60,11 +60,11 @@ class Attributes implements ArrayAccess, IteratorAggregate
     /**
      * Create new HTML attributes
      *
-     * @param AttributesType $attributes
+     * @param ?AttributesType $attributes
      *
      * @return static
      */
-    public static function create(array $attributes = null)
+    public static function create(?array $attributes = null)
     {
         return new static($attributes);
     }

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -408,7 +408,6 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
         $attributes = $this->getAttributes();
 
         $callbacksProperty = new ReflectionProperty(get_class($attributes), 'callbacks');
-        $callbacksProperty->setAccessible(true);
         $callbacks = $callbacksProperty->getValue($attributes);
 
         if (isset($callbacks['name'])) {

--- a/src/FormElement/RadioElement.php
+++ b/src/FormElement/RadioElement.php
@@ -66,7 +66,7 @@ class RadioElement extends BaseFormElement
      *
      * @throws InvalidArgumentException If no option with the specified value exists
      */
-    public function getOption($value): RadioOption
+    public function getOption(string|int $value): RadioOption
     {
         if (! isset($this->options[$value])) {
             throw new InvalidArgumentException(sprintf('There is no such option "%s"', $value));
@@ -127,10 +127,15 @@ class RadioElement extends BaseFormElement
                     'checked',
                     function () use ($option) {
                         $optionValue = $option->getValue();
+                        $value = $this->getValue();
+
+                        if ($optionValue === '' && $value === null) {
+                            return true;
+                        }
 
                         return ! is_int($optionValue)
-                            ? $this->getValue() === $optionValue
-                            : $this->getValue() == $optionValue;
+                            ? $value === $optionValue
+                            : $value == $optionValue;
                     }
                 )
                 ->registerAttributeCallback(

--- a/src/FormElement/RadioOption.php
+++ b/src/FormElement/RadioOption.php
@@ -9,7 +9,7 @@ class RadioOption
     /** @var string The default label class */
     public const LABEL_CLASS = 'radio-label';
 
-    /** @var string|int|null Value of the option */
+    /** @var string|int Value of the option */
     protected $value;
 
     /** @var string Label of the option */
@@ -27,12 +27,12 @@ class RadioOption
     /**
      * RadioOption constructor.
      *
-     * @param string|int|null $value
+     * @param string|int $value
      * @param string $label
      */
-    public function __construct($value, string $label)
+    public function __construct(string|int $value, string $label)
     {
-        $this->value = $value === '' ? null : $value;
+        $this->value = $value;
         $this->label = $label;
     }
 
@@ -63,9 +63,9 @@ class RadioOption
     /**
      * Get the value of the option
      *
-     * @return string|int|null
+     * @return string|int
      */
-    public function getValue()
+    public function getValue(): string|int
     {
         return $this->value;
     }

--- a/src/FormElement/SelectElement.php
+++ b/src/FormElement/SelectElement.php
@@ -2,7 +2,6 @@
 
 namespace ipl\Html\FormElement;
 
-use InvalidArgumentException;
 use ipl\Html\Attributes;
 use ipl\Html\Common\MultipleAttribute;
 use ipl\Html\Html;
@@ -32,11 +31,11 @@ class SelectElement extends BaseFormElement
     /**
      * Get the option with specified value
      *
-     * @param string|int|null $value
+     * @param string|int $value
      *
      * @return ?SelectOption
      */
-    public function getOption($value): ?SelectOption
+    public function getOption(string|int $value): ?SelectOption
     {
         return $this->options[$value] ?? null;
     }
@@ -75,7 +74,7 @@ class SelectElement extends BaseFormElement
                 $option->setAttribute(
                     'disabled',
                     in_array($optionValue, $disabledOptions, ! is_int($optionValue))
-                    || ($optionValue === null && in_array('', $disabledOptions, true))
+                    || ($optionValue === '' && in_array(null, $disabledOptions, true))
                 );
             }
 
@@ -119,12 +118,12 @@ class SelectElement extends BaseFormElement
     /**
      * Make the selectOption for the specified value and the label
      *
-     * @param string|int|null $value Value of the option
+     * @param string|int $value Value of the option
      * @param string|array $label Label of the option
      *
      * @return SelectOption|HtmlElement
      */
-    protected function makeOption($value, $label)
+    protected function makeOption(string|int $value, string|array $label)
     {
         if (is_array($label)) {
             $grp = Html::tag('optgroup', ['label' => $value]);
@@ -150,17 +149,13 @@ class SelectElement extends BaseFormElement
     /**
      * Get whether the given option is selected
      *
-     * @param int|string|null $optionValue
+     * @param string|int $optionValue
      *
      * @return bool
      */
-    protected function isSelectedOption($optionValue): bool
+    protected function isSelectedOption(string|int $optionValue): bool
     {
         $value = $this->getValue();
-
-        if ($optionValue === '') {
-            $optionValue = null;
-        }
 
         if ($this->isMultiple()) {
             if (! is_array($value)) {
@@ -169,14 +164,18 @@ class SelectElement extends BaseFormElement
                 );
             }
 
-            return in_array($optionValue, $this->getValue(), ! is_int($optionValue))
-                || ($optionValue === null && in_array('', $this->getValue(), true));
+            return in_array($optionValue, $value, ! is_int($optionValue))
+                || ($optionValue === '' && in_array(null, $value, true));
         }
 
         if (is_array($value)) {
             throw new UnexpectedValueException(
                 'Value cannot be an array without setting the `multiple` attribute to `true`'
             );
+        }
+
+        if ($optionValue === '' && $value === null) {
+            return true;
         }
 
         return is_int($optionValue)

--- a/src/FormElement/SelectOption.php
+++ b/src/FormElement/SelectOption.php
@@ -8,7 +8,7 @@ class SelectOption extends BaseHtmlElement
 {
     protected $tag = 'option';
 
-    /** @var string|int|null Value of the option */
+    /** @var string|int Value of the option */
     protected $value;
 
     /** @var string Label of the option */
@@ -17,12 +17,12 @@ class SelectOption extends BaseHtmlElement
     /**
      * SelectOption constructor.
      *
-     * @param string|int|null $value
+     * @param string|int $value
      * @param string $label
      */
-    public function __construct($value, string $label)
+    public function __construct(string|int $value, string $label)
     {
-        $this->value = $value === '' ? null : $value;
+        $this->value = $value;
         $this->label = $label;
 
         $this->getAttributes()->registerAttributeCallback('value', [$this, 'getValueAttribute']);
@@ -55,7 +55,7 @@ class SelectOption extends BaseHtmlElement
     /**
      * Get the value of the option
      *
-     * @return string|int|null
+     * @return string|int
      */
     public function getValue()
     {

--- a/src/HtmlElement.php
+++ b/src/HtmlElement.php
@@ -13,10 +13,10 @@ class HtmlElement extends BaseHtmlElement
      * Create a new HTML element from the given tag, attributes and content
      *
      * @param string     $tag        The tag for the element
-     * @param Attributes $attributes The HTML attributes for the element
+     * @param ?Attributes $attributes The HTML attributes for the element
      * @param ValidHtml  ...$content The content of the element
      */
-    public function __construct($tag, Attributes $attributes = null, ValidHtml ...$content)
+    public function __construct($tag, ?Attributes $attributes = null, ValidHtml ...$content)
     {
         $this->tag = $tag;
 

--- a/tests/DocumentationFormsTest.php
+++ b/tests/DocumentationFormsTest.php
@@ -25,7 +25,7 @@ class DocumentationFormsTest extends TestCase
         $form->addElement('select', 'customer', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -57,7 +57,7 @@ class DocumentationFormsTest extends TestCase
         $form->addElement('select', 'customer', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',

--- a/tests/FormElement/FieldsetElementTest.php
+++ b/tests/FormElement/FieldsetElementTest.php
@@ -15,7 +15,7 @@ use LogicException;
 class FieldsetElementTest extends TestCase
 {
     private const SELECT_OPTIONS_TO_TEST = [
-        null  => 'Nothing',
+        ''    => 'Nothing',
         1     => 'One',
         'two' => 2,
     ];

--- a/tests/FormElement/RadioElementTest.php
+++ b/tests/FormElement/RadioElementTest.php
@@ -282,7 +282,7 @@ HTML;
         $this->assertFalse($radio->isValid());
     }
 
-    public function testNullAndTheEmptyStringAreEquallyHandled()
+    public function testNullAndTheEmptyStringValuesAreEquallyHandled()
     {
         $form = new Form();
         $form->addElement('radio', 'radio', [
@@ -303,8 +303,6 @@ HTML;
         $this->assertNull($radio2->getValue());
 
         $this->assertInstanceOf(RadioOption::class, $radio->getOption(''));
-        $this->assertInstanceOf(RadioOption::class, $radio2->getOption(null));
-        $this->assertInstanceOf(RadioOption::class, $radio->getOption(null));
         $this->assertInstanceOf(RadioOption::class, $radio2->getOption(''));
 
         $this->assertTrue($radio->isValid());
@@ -401,7 +399,7 @@ HTML;
         $radio = new RadioElement('radio');
         $radio->setOptions(['' => 'Empty String', 'foo' => 'Foo', 'bar' => 'Bar']);
 
-        $this->assertNull($radio->getOption('')->getValue());
+        $this->assertSame('', $radio->getOption('')->getValue());
         $this->assertSame('Empty String', $radio->getOption('')->getLabel());
 
         $this->assertSame('foo', $radio->getOption('foo')->getValue());
@@ -409,24 +407,18 @@ HTML;
 
         $radio->setOptions(['' => 'Please Choose', 'car' => 'Car', 'train' => 'Train']);
 
-        $this->assertNull($radio->getOption('')->getValue());
+        $this->assertSame('', $radio->getOption('')->getValue());
         $this->assertSame('Please Choose', $radio->getOption('')->getLabel());
 
         $this->assertSame('car', $radio->getOption('car')->getValue());
         $this->assertSame('Car', $radio->getOption('car')->getLabel());
     }
 
-    public function testNullAndTheEmptyStringAreAlsoEquallyHandledWhileDisablingOptions()
+    public function testNullAndTheEmptyStringAreEquallyHandledWhileDisablingOptions()
     {
         $radio = new RadioElement('radio');
         $radio->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $radio->setDisabledOptions([null]);
-
-        $this->assertTrue($radio->getOption(null)->isDisabled());
-
-        $radio = new RadioElement('radio');
-        $radio->setOptions(['' => 'Foo', 'bar' => 'Bar']);
-        $radio->setDisabledOptions(['']);
 
         $this->assertTrue($radio->getOption('')->isDisabled());
 
@@ -434,28 +426,7 @@ HTML;
         $radio->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $radio->setDisabledOptions(['']);
 
-        $this->assertTrue($radio->getOption(null)->isDisabled());
-        $radio = new RadioElement('radio');
-        $radio->setOptions(['' => 'Foo', 'bar' => 'Bar']);
-        $radio->setDisabledOptions([null]);
-
         $this->assertTrue($radio->getOption('')->isDisabled());
-    }
-
-    public function testGetOptionGetValueAndElementGetValueHandleNullAndTheEmptyStringEqually()
-    {
-        $radio = new RadioElement('radio');
-        $radio->setOptions(['' => 'Foo']);
-        $radio->setValue('');
-
-        $this->assertNull($radio->getValue());
-        $this->assertNull($radio->getOption('')->getValue());
-
-        $radio = new RadioElement('radio');
-        $radio->setOptions(['' => 'Foo']);
-
-        $this->assertNull($radio->getValue());
-        $this->assertNull($radio->getOption(null)->getValue());
     }
 
     public function testIsDecoratedWithLabelAndDescription(): void

--- a/tests/FormElement/RadioElementTest.php
+++ b/tests/FormElement/RadioElementTest.php
@@ -290,7 +290,7 @@ HTML;
             'value' => ''
         ]);
         $form->addElement('radio', 'radio2', [
-            'options' => [null => 'Please choose'],
+            'options' => ['' => 'Please choose'],
             'value' => null
         ]);
 
@@ -419,7 +419,7 @@ HTML;
     public function testNullAndTheEmptyStringAreAlsoEquallyHandledWhileDisablingOptions()
     {
         $radio = new RadioElement('radio');
-        $radio->setOptions([null => 'Foo', 'bar' => 'Bar']);
+        $radio->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $radio->setDisabledOptions([null]);
 
         $this->assertTrue($radio->getOption(null)->isDisabled());
@@ -431,7 +431,7 @@ HTML;
         $this->assertTrue($radio->getOption('')->isDisabled());
 
         $radio = new RadioElement('radio');
-        $radio->setOptions([null => 'Foo', 'bar' => 'Bar']);
+        $radio->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $radio->setDisabledOptions(['']);
 
         $this->assertTrue($radio->getOption(null)->isDisabled());
@@ -452,7 +452,7 @@ HTML;
         $this->assertNull($radio->getOption('')->getValue());
 
         $radio = new RadioElement('radio');
-        $radio->setOptions([null => 'Foo']);
+        $radio->setOptions(['' => 'Foo']);
 
         $this->assertNull($radio->getValue());
         $this->assertNull($radio->getOption(null)->getValue());

--- a/tests/FormElement/RadioElementTest.php
+++ b/tests/FormElement/RadioElementTest.php
@@ -341,6 +341,12 @@ HTML;
 HTML;
 
         $this->assertHtml($html, $radio2);
+
+        $radio->setValue(null);
+        $this->assertNull($radio->getValue());
+
+        $radio2->setValue('');
+        $this->assertNull($radio2->getValue());
     }
 
     public function testSetOptionsResetsOptions()
@@ -469,5 +475,112 @@ HTML;
 
         $radio->applyDecoration();
         $this->assertHtml($html, $radio);
+    }
+
+    public function testSetDisabledOptionsResetsDisabledOptions()
+    {
+        $radio = new RadioElement('test', [
+            'options'   => [
+                '1' => 'Foo',
+                2   => 'Bar',
+                3   => 'Yes'
+            ]
+        ]);
+
+        $radio->setDisabledOptions(['1']);
+        $this->assertTrue($radio->getOption('1')->isDisabled());
+        $this->assertFalse($radio->getOption(2)->isDisabled());
+        $this->assertFalse($radio->getOption(3)->isDisabled());
+
+        $radio->setDisabledOptions([3]);
+        $this->assertFalse($radio->getOption('1')->isDisabled());
+        $this->assertFalse($radio->getOption(2)->isDisabled());
+        $this->assertTrue($radio->getOption(3)->isDisabled());
+
+        $radio->setDisabledOptions([]);
+        $this->assertFalse($radio->getOption('1')->isDisabled());
+        $this->assertFalse($radio->getOption(2)->isDisabled());
+        $this->assertFalse($radio->getOption(3)->isDisabled());
+    }
+
+
+    public function testEmptyStringOptionCannotBeDisabledByFalsyValuesExceptNullOrEmptyString()
+    {
+        $radio = new RadioElement('test', [
+            'options' => [
+                ''      => 'Option to disable',
+                'foo'   => 'Foo'
+            ]
+        ]);
+
+        $radio->setDisabledOptions([false, 0, [], 0.0]);
+        $this->assertFalse($radio->getOption('')->isDisabled());
+
+        $radio->setDisabledOptions([null]);
+        $this->assertTrue($radio->getOption('')->isDisabled());
+
+        $radio->setDisabledOptions(['']);
+        $this->assertTrue($radio->getOption('')->isDisabled());
+    }
+
+    public function testEmptyStringOptionCannotBeCheckedByFalsyValuesExceptNullOrEmptyString()
+    {
+        $radio = new RadioElement('test', [
+            'options' => [
+                ''      => 'Option to check',
+                'foo'   => 'Foo'
+            ]
+        ]);
+
+        $radio->setValue(false);
+        $this->assertStringNotContainsString('checked', $radio->render());
+
+        $radio->setValue(0);
+        $this->assertStringNotContainsString('checked', $radio->render());
+
+        $radio->setValue([]);
+        $this->assertStringNotContainsString('checked', $radio->render());
+
+        $radio->setValue(0.0);
+        $this->assertStringNotContainsString('checked', $radio->render());
+
+        $radio->setValue('');
+        $this->assertStringContainsString('checked', $radio->render());
+
+        $radio->setValue(null);
+        $this->assertStringContainsString('checked', $radio->render());
+    }
+
+    public function testDisabledOptionsCanBePreSet()
+    {
+        $radio = new RadioElement('test', [
+            'disabledOptions' => ['foo']
+        ]);
+        $radio->setOptions(['foo' => 'Foo', 'bar' => 'Bar']);
+
+        $this->assertTrue($radio->getOption('foo')->isDisabled());
+        $this->assertFalse($radio->getOption('bar')->isDisabled());
+    }
+
+    public function testGetOptionThrowsExceptionIfOptionDoesNotExist()
+    {
+        $radio = new RadioElement('test');
+        $radio->setOptions(['foo' => 'Foo']);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('There is no such option "bar"');
+        $radio->getOption('bar');
+    }
+
+    public function testAttributesAreAppliedToAllOptions()
+    {
+        $radio = new RadioElement('test', [
+            'options' => ['foo' => 'Foo', 'bar' => 'Bar'],
+            'class'   => 'my-radio'
+        ]);
+
+        $html = $radio->render();
+        $this->assertStringContainsString('class="my-radio"', $html);
+        $this->assertSame(2, substr_count($html, 'class="my-radio"'));
     }
 }

--- a/tests/FormElement/SelectElementTest.php
+++ b/tests/FormElement/SelectElementTest.php
@@ -17,7 +17,7 @@ class SelectElementTest extends TestCase
         $select = new SelectElement('elname', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -43,7 +43,7 @@ HTML;
             'label'   => 'Customer',
             'value'   => '3',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -72,7 +72,7 @@ HTML;
             'label'   => 'Customer',
             'value'   => '4',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -93,7 +93,7 @@ HTML;
         $select = new SelectElement('elname', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                '' => 'Please choose',
                 'Some Options' => [
                     '1'  => 'The one',
                     '4'  => 'Four',
@@ -125,7 +125,7 @@ HTML;
         $select = new SelectElement('elname', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                '' => 'Please choose',
                 'Some options' => [
                     '1'  => 'The one',
                     '4'  => 'Four',
@@ -160,7 +160,7 @@ HTML;
         $select = new SelectElement('elname', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                '' => 'Please choose',
                 'Some options' => [
                     '1'  => 'The one',
                     '4'  => [
@@ -204,7 +204,7 @@ HTML;
             'label'   => 'Customer',
             'value'   => '1',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -228,7 +228,7 @@ HTML;
         $select = new SelectElement('elname', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -280,7 +280,7 @@ HTML;
         $select = new SelectElement('elname', [
             'label'     => 'Customer',
             'options'   => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -301,7 +301,7 @@ HTML;
             'label'     => 'Customer',
             'multiple'  => true,
             'options'   => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -323,7 +323,7 @@ HTML;
         $select = new SelectElement('elname', [
             'label'   => 'Customer',
             'options' => [
-                null => 'Please choose',
+                ''   => 'Please choose',
                 '1'  => 'The one',
                 '4'  => 'Four',
                 '5'  => 'Hi five',
@@ -449,7 +449,7 @@ HTML;
             'value' => ''
         ]);
         $form->addElement('select', 'select2', [
-            'options' => [null => 'Please choose'],
+            'options' => ['' => 'Please choose'],
             'value' => null
         ]);
 
@@ -506,7 +506,7 @@ HTML;
         $this->assertNull($select->getOption('')->getValue());
 
         $select = new SelectElement('select');
-        $select->setOptions([null => 'Foo']);
+        $select->setOptions(['' => 'Foo']);
 
         $this->assertNull($select->getValue());
         $this->assertNull($select->getOption(null)->getValue());
@@ -539,7 +539,7 @@ HTML;
     public function testNullAndTheEmptyStringAreAlsoEquallyHandledWhileDisablingOptions()
     {
         $select = new SelectElement('select');
-        $select->setOptions([null => 'Foo', 'bar' => 'Bar']);
+        $select->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $select->setDisabledOptions([null]);
 
         $this->assertTrue($select->getOption(null)->getAttributes()->get('disabled')->getValue());
@@ -551,7 +551,7 @@ HTML;
         $this->assertTrue($select->getOption('')->getAttributes()->get('disabled')->getValue());
 
         $select = new SelectElement('select');
-        $select->setOptions([null => 'Foo', 'bar' => 'Bar']);
+        $select->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $select->setDisabledOptions(['']);
 
         $this->assertTrue($select->getOption(null)->getAttributes()->get('disabled')->getValue());

--- a/tests/FormElement/SelectElementTest.php
+++ b/tests/FormElement/SelectElementTest.php
@@ -488,6 +488,12 @@ HTML;
 </select>
 HTML;
         $this->assertHtml($html, $select2);
+
+        $select->setValue(null);
+        $this->assertNull($select->getValue());
+
+        $select2->setValue('');
+        $this->assertNull($select2->getValue());
     }
 
     public function testGetOptionGetValueAndElementGetValueHandleNullAndTheEmptyStringEqually()
@@ -597,10 +603,10 @@ HTML;
 
         $select->setOptions(['car' => 'Car', 'train' => 'Train']);
 
+        $this->assertNull($select->getOption('foo'));
+        $this->assertNull($select->getOption('bar'));
         $this->assertInstanceOf(SelectOption::class, $select->getOption('car'));
         $this->assertInstanceOf(SelectOption::class, $select->getOption('train'));
-
-        $this->assertNull($select->getOption('foo'));
     }
 
     public function testGetOptionReturnsPreviouslySetOption()
@@ -615,5 +621,146 @@ HTML;
 
         $this->assertNull($select->getOption('')->getValue());
         $this->assertSame('car', $select->getOption('car')->getValue());
+    }
+
+    public function testSetDisabledOptionsResetsDisabledOptions()
+    {
+        $select = new SelectElement('test', [
+            'options'   => [
+                '1' => 'Foo',
+                2   => 'Bar',
+                3   => 'Yes'
+            ]
+        ]);
+
+        $select->setDisabledOptions(['1']);
+        $this->assertTrue($select->getOption('1')->getAttributes()->get('disabled')->getValue());
+        $this->assertFalse($select->getOption(2)->getAttributes()->get('disabled')->getValue());
+        $this->assertFalse($select->getOption(3)->getAttributes()->get('disabled')->getValue());
+
+        $select->setDisabledOptions([3]);
+        $this->assertFalse($select->getOption('1')->getAttributes()->get('disabled')->getValue());
+        $this->assertFalse($select->getOption(2)->getAttributes()->get('disabled')->getValue());
+        $this->assertTrue($select->getOption(3)->getAttributes()->get('disabled')->getValue());
+
+        $select->setDisabledOptions([]);
+        $this->assertFalse($select->getOption('1')->getAttributes()->get('disabled')->getValue());
+        $this->assertFalse($select->getOption(2)->getAttributes()->get('disabled')->getValue());
+        $this->assertFalse($select->getOption(3)->getAttributes()->get('disabled')->getValue());
+    }
+
+    public function testEmptyStringOptionCannotBeDisabledByFalsyValuesExceptNullOrEmptyString()
+    {
+        $select = new SelectElement('test', [
+            'options' => [
+                ''      => 'Option to disable',
+                'foo'   => 'Foo'
+            ]
+        ]);
+
+        $select->setDisabledOptions([false, 0, [], 0.0]);
+        $this->assertFalse($select->getOption('')->getAttributes()->get('disabled')->getValue());
+
+        $select->setDisabledOptions([null]);
+        $this->assertTrue($select->getOption('')->getAttributes()->get('disabled')->getValue());
+
+        $select->setDisabledOptions(['']);
+        $this->assertTrue($select->getOption('')->getAttributes()->get('disabled')->getValue());
+    }
+
+    public function testEmptyStringOptionCannotBeSelectedByFalsyValuesExceptNullOrEmptyString()
+    {
+        $select = new SelectElement('test', [
+            'options' => [
+                ''      => 'Option to select',
+                'foo'   => 'Foo'
+            ]
+        ]);
+
+        $select->setValue(false);
+        $this->assertStringNotContainsString('selected', $select->render());
+
+        $select->setValue(0);
+        $this->assertStringNotContainsString('selected', $select->render());
+
+        $select->setValue(0.0);
+        $this->assertStringNotContainsString('selected', $select->render());
+
+        $select->setValue('');
+        $this->assertStringContainsString('selected', $select->render());
+
+        $select->setValue(null);
+        $this->assertStringContainsString('selected', $select->render());
+    }
+
+    public function testNumbersOfTypeIntOrStringAsOptionKeysAreHandledEqually()
+    {
+        $select = new SelectElement('test', [
+            'label'     => 'Test',
+            'options'   => [
+                '1' => 'Foo',
+                2   => 'Bar',
+                3   => 'Yes'
+            ]
+        ]);
+
+        $select->setValue(2);
+
+        $html = <<<'HTML'
+<select name="test">
+    <option value="1">Foo</option>
+    <option value="2" selected>Bar</option>
+    <option value="3">Yes</option>
+</select>
+HTML;
+        $this->assertHtml($html, $select);
+
+        $select->setValue('2');
+        $this->assertHtml($html, $select);
+
+        $select->setDisabledOptions([2]);
+        $this->assertTrue($select->getOption(2)->getAttributes()->get('disabled')->getValue());
+
+        $select->setDisabledOptions(['2']);
+        $this->assertTrue($select->getOption(2)->getAttributes()->get('disabled')->getValue());
+
+        $select->setOptions([]);
+
+        $select->setDisabledOptions(['5']);
+
+        $select->setOptions(['5' => 'Five', 8 => 'Eight']);
+        $this->assertTrue($select->getOption(5)->getAttributes()->get('disabled')->getValue());
+
+        $select->getOption(5)->getAttributes()->get('disabled')->setValue(false);
+        $this->assertFalse($select->getOption(5)->getAttributes()->get('disabled')->getValue());
+    }
+
+    public function testDisabledOptionsCanBePreSet()
+    {
+        $select = new SelectElement('test', [
+            'disabledOptions' => ['foo']
+        ]);
+        $select->setOptions(['foo' => 'Foo', 'bar' => 'Bar']);
+
+        $this->assertTrue($select->getOption('foo')->getAttributes()->get('disabled')->getValue());
+        $this->assertFalse($select->getOption('bar')->getAttributes()->get('disabled')->getValue());
+    }
+
+    public function testGetOptionReturnsNullIfOptionDoesNotExist()
+    {
+        $select = new SelectElement('test');
+        $select->setOptions(['foo' => 'Foo']);
+
+        $this->assertNull($select->getOption('bar'));
+    }
+
+    public function testMultiOptionsAttributeIsSupportedForZf1Compatibility()
+    {
+        $select = new SelectElement('test', [
+            'multiOptions' => ['foo' => 'Foo', 'bar' => 'Bar']
+        ]);
+
+        $this->assertInstanceOf(SelectOption::class, $select->getOption('foo'));
+        $this->assertInstanceOf(SelectOption::class, $select->getOption('bar'));
     }
 }

--- a/tests/FormElement/SelectElementTest.php
+++ b/tests/FormElement/SelectElementTest.php
@@ -441,7 +441,7 @@ HTML;
         $this->assertSame([], $select->getValue());
     }
 
-    public function testNullAndTheEmptyStringAreEquallyHandled()
+    public function testNullAndTheEmptyStringValuesAreEquallyHandled()
     {
         $form = new Form();
         $form->addElement('select', 'select', [
@@ -462,8 +462,6 @@ HTML;
         $this->assertNull($select2->getValue());
 
         $this->assertInstanceOf(SelectOption::class, $select->getOption(''));
-        $this->assertInstanceOf(SelectOption::class, $select2->getOption(null));
-        $this->assertInstanceOf(SelectOption::class, $select->getOption(null));
         $this->assertInstanceOf(SelectOption::class, $select2->getOption(''));
 
         $this->assertTrue($select->isValid());
@@ -496,25 +494,6 @@ HTML;
         $this->assertNull($select2->getValue());
     }
 
-    public function testGetOptionGetValueAndElementGetValueHandleNullAndTheEmptyStringEqually()
-    {
-        $select = new SelectElement('select');
-        $select->setOptions(['' => 'Foo']);
-        $select->setValue('');
-
-        $this->assertNull($select->getValue());
-        $this->assertNull($select->getOption('')->getValue());
-
-        $select = new SelectElement('select');
-        $select->setOptions(['' => 'Foo']);
-
-        $this->assertNull($select->getValue());
-        $this->assertNull($select->getOption(null)->getValue());
-    }
-
-    /**
-     * @depends testNullAndTheEmptyStringAreEquallyHandled
-     */
     public function testDisablingOptionsIsWorking()
     {
         $form = new Form();
@@ -536,28 +515,17 @@ HTML;
         $this->assertHtml($html, $form->getElement('select'));
     }
 
-    public function testNullAndTheEmptyStringAreAlsoEquallyHandledWhileDisablingOptions()
+    public function testNullAndTheEmptyStringAreEquallyHandledWhileDisablingOptions()
     {
         $select = new SelectElement('select');
         $select->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $select->setDisabledOptions([null]);
-
-        $this->assertTrue($select->getOption(null)->getAttributes()->get('disabled')->getValue());
-
-        $select = new SelectElement('select');
-        $select->setOptions(['' => 'Foo', 'bar' => 'Bar']);
-        $select->setDisabledOptions(['']);
 
         $this->assertTrue($select->getOption('')->getAttributes()->get('disabled')->getValue());
 
         $select = new SelectElement('select');
         $select->setOptions(['' => 'Foo', 'bar' => 'Bar']);
         $select->setDisabledOptions(['']);
-
-        $this->assertTrue($select->getOption(null)->getAttributes()->get('disabled')->getValue());
-        $select = new SelectElement('select');
-        $select->setOptions(['' => 'Foo', 'bar' => 'Bar']);
-        $select->setDisabledOptions([null]);
 
         $this->assertTrue($select->getOption('')->getAttributes()->get('disabled')->getValue());
     }
@@ -614,13 +582,19 @@ HTML;
         $select = new SelectElement('select');
         $select->setOptions(['' => 'Empty String', 'foo' => 'Foo', 'bar' => 'Bar']);
 
-        $this->assertNull($select->getOption('')->getValue());
+        $this->assertSame('', $select->getOption('')->getValue());
+        $this->assertSame('Empty String', $select->getOption('')->getLabel());
+
         $this->assertSame('foo', $select->getOption('foo')->getValue());
+        $this->assertSame('Foo', $select->getOption('foo')->getLabel());
 
         $select->setOptions(['' => 'Please Choose', 'car' => 'Car', 'train' => 'Train']);
 
-        $this->assertNull($select->getOption('')->getValue());
+        $this->assertSame('', $select->getOption('')->getValue());
+        $this->assertSame('Please Choose', $select->getOption('')->getLabel());
+
         $this->assertSame('car', $select->getOption('car')->getValue());
+        $this->assertSame('Car', $select->getOption('car')->getLabel());
     }
 
     public function testSetDisabledOptionsResetsDisabledOptions()


### PR DESCRIPTION
## Changes made:
### PHP 8.4:
- [Function parameters that are null by default must be declared nullable](https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core).

### PHP 8.5:
- [Using null as an array offset is deprecated.](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.core.using-null-as-an-array-offset)
- Remove deprecated method [`ReflectionProperty::setAccesible()`](https://www.php.net/manual/en/migration85.deprecated.php#migration85.deprecated.reflection)

### Other changes:
- Update composer package `guzzlehttp/psr7`

resolves #181