### PR TITLE
`DescriptionDecorator`: Do not override existing `aria-describedby`

### DIFF
--- a/src/FormDecoration/DescriptionDecorator.php
+++ b/src/FormDecoration/DescriptionDecorator.php
@@ -74,7 +74,7 @@ class DescriptionDecorator implements FormElementDecoration, DecoratorOptionsInt
             }
 
             $descriptionId = 'desc_' . $elementId;
-            $formElement->getAttributes()->set('aria-describedby', $descriptionId);
+            $formElement->getAttributes()->add('aria-describedby', $descriptionId);
 
             $elementDescription->getAttributes()->set('id', $descriptionId);
         }

--- a/tests/FormDecorator/DescriptionDecoratorTest.php
+++ b/tests/FormDecorator/DescriptionDecoratorTest.php
@@ -91,6 +91,23 @@ class DescriptionDecoratorTest extends TestCase
         $this->assertHtml('<p class="form-element-description" id="desc_test-id"></p>', $results->assemble());
     }
 
+    public function testAriaDescribedByIsAppendedIfAlreadyExists(): void
+    {
+        $element = new TextElement('test', [
+            'description'       => 'Testing',
+            'id'                => 'test-id',
+            'aria-describedby'  => 'preset-id'
+        ]);
+
+        $this->decorator->decorateFormElement(new FormElementDecorationResult(), $element);
+
+        $this->assertTrue($element->getAttributes()->has('aria-describedby'));
+        $this->assertSame(
+            ['preset-id', 'desc_test-id'],
+            $element->getAttributes()->get('aria-describedby')->getValue()
+        );
+    }
+
     public function testWithoutDescriptionAttribute(): void
     {
         $results = new FormElementDecorationResult();


### PR DESCRIPTION
An element can have multiple `aria-describedby` IDs. For example, a `checkbox` may have both a description and an autosubmit spinner associated with it.