### PR TITLE
Adapt strict type declarations in `FormElements::isValidEvent()`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
   "require": {
     "php": ">=8.2",
     "ext-fileinfo": "*",
-    "ipl/stdlib": ">=0.12.0",
+    "ipl/stdlib": "dev-modernize-code-with-breaking-changes",
     "ipl/validator": ">=0.5.0",
     "psr/http-message": "^1.1",
     "guzzlehttp/psr7": "^2.8"
   },
   "require-dev": {
     "ext-dom": "*",
-    "ipl/stdlib": "dev-main",
+    "ipl/stdlib": "dev-modernize-code-with-breaking-changes",
     "ipl/validator": "dev-main"
   },
   "autoload": {

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -536,7 +536,7 @@ trait FormElements
         return $this;
     }
 
-    public function isValidEvent($event)
+    public function isValidEvent(string $event): bool
     {
         return in_array($event, [
             Form::ON_SUBMIT,


### PR DESCRIPTION
Add strict types to `FormElements::isValidEvent()`.

requires https://github.com/Icinga/ipl-stdlib/pull/69