### PR TITLE
Repository housekeeping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Exclude Git and CI configuration files from archives.
+.git* export-ignore
+
+# Exclude test-related files from archives.
+tests/ export-ignore
+phpstan* export-ignore

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
+      - support/*
   pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
   php:

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,5 @@
-# Exclude all hidden files
-.*
-
-# Except those related to Git and GitHub
-!.git*
-!.github*
-
-# Exclude files from composer install
-vendor/
+# Ignore Composer installation artifacts; composer.lock is intentionally
+# excluded as this is a library - applications depending on this package
+# manage their own lock file.
+/vendor/
 composer.lock

--- a/composer.json
+++ b/composer.json
@@ -1,20 +1,19 @@
 {
   "name": "ipl/html",
-  "type": "library",
   "description": "Icinga PHP Library - HTML abstraction layer",
   "license": "MIT",
-  "keywords": ["html"],
+  "type": "library",
+  "keywords": [
+    "html"
+  ],
   "homepage": "https://github.com/Icinga/ipl-html",
-  "config": {
-    "sort-packages": true
-  },
   "require": {
     "php": ">=8.2",
     "ext-fileinfo": "*",
+    "guzzlehttp/psr7": "^2.8",
     "ipl/stdlib": ">=0.15.0",
     "ipl/validator": ">=1.0.0",
-    "psr/http-message": "^1.1",
-    "guzzlehttp/psr7": "^2.8"
+    "psr/http-message": "^1.1"
   },
   "require-dev": {
     "ext-dom": "*",
@@ -30,5 +29,8 @@
     "psr-4": {
       "ipl\\Tests\\Html\\": "tests"
     }
+  },
+  "config": {
+    "sort-packages": true
   }
 }


### PR DESCRIPTION
Apply a set of maintenance changes to normalize repository configuration:

- Extend CI to build on `support/*` branches, run for all PRs
  regardless of target, and allow manual dispatch
- Normalize `composer.json`
- Add `.gitattributes` to exclude CI and test files from `git archive`
- Tighten `.gitignore` to cover only Composer artifacts