### PR TITLE
Move `TestCase` to `ipl\Html\Test` and clean up for PHP 8.2

### DIFF
--- a/src/Test/TestCase.php
+++ b/src/Test/TestCase.php
@@ -4,37 +4,31 @@ namespace ipl\Html\Test;
 
 use DOMDocument;
 use ipl\Html\ValidHtml;
+use PHPUnit\Framework\TestCase as BaseTestCase;
 
-// phpcs:disable
-if (class_exists('PHPUnit_Util_XML')) {
-    // Support older PHPUnit versions
-    class_alias('PHPUnit_Util_XML', 'PHPUnit\\Util\\Xml');
-}
-
-// phpcs:enable
-
-abstract class TestCase extends \PHPUnit\Framework\TestCase
+abstract class TestCase extends BaseTestCase
 {
     /**
      * Assert that HTML is equal
      *
-     * @param string    $expectedHtml
+     * @param string    $expected
      * @param ValidHtml $actual
      */
-    protected function assertHtml($expectedHtml, ValidHtml $actualHtml)
+    protected function assertHtml(string $expected, ValidHtml $actual): void
     {
         $expectedHtml = str_replace(
             "\n",
             '',
-            preg_replace('/^\s+/m', '', trim($expectedHtml))
+            preg_replace('/^\s+/m', '', trim($expected))
         );
+        $actualHtml = $actual->render();
 
-        $expected = new DOMDocument();
-        $this->assertTrue($expected->loadHTML($expectedHtml), 'Expected HTML is not valid');
-        $actual = new DOMDocument();
-        $this->assertTrue($actual->loadHTML($actualHtml->render()), 'Actual HTML is not valid');
+        $expectedDom = new DOMDocument();
+        $this->assertTrue($expectedDom->loadHTML($expectedHtml), 'Expected HTML is not valid');
+        $actualDom = new DOMDocument();
+        $this->assertTrue($actualDom->loadHTML($actualHtml), 'Actual HTML is not valid');
 
-        $this->assertEquals($expected, $actual);
+        $this->assertEquals($expectedDom, $actualDom);
     }
 
     /**
@@ -42,7 +36,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * processed must have a root node, e.g. the HTML `<b>foo</b><b>bar</b>` would always fail with "Extra content at
      * the end of the document". {@link assertHtml()} just does the job.
      */
-    protected function assertRendersHtml($html, ValidHtml $element)
+    protected function assertRendersHtml(string $html, ValidHtml $element): void
     {
         $this->assertXmlStringEqualsXmlString($html, $element->render());
     }

--- a/src/Test/TestCase.php
+++ b/src/Test/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ipl\Tests\Html;
+namespace ipl\Html\Test;
 
 use DOMDocument;
 use ipl\Html\ValidHtml;

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\Attribute;
+use ipl\Html\Test\TestCase;
 
 class AttributeTest extends TestCase
 {

--- a/tests/AttributesTest.php
+++ b/tests/AttributesTest.php
@@ -6,6 +6,7 @@ use ipl\Html\Attribute;
 use ipl\Html\Attributes;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlString;
+use ipl\Html\Test\TestCase;
 use ipl\Html\ValidHtml;
 
 class AttributesTest extends TestCase

--- a/tests/BaseHtmlElementTest.php
+++ b/tests/BaseHtmlElementTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\HtmlString;
+use ipl\Html\Test\TestCase;
 use RuntimeException;
 
 class BaseHtmlElementTest extends TestCase

--- a/tests/DeferredTextTest.php
+++ b/tests/DeferredTextTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\DeferredText;
+use ipl\Html\Test\TestCase;
 use Exception;
 
 class DeferredTextTest extends TestCase

--- a/tests/DocumentationFormsTest.php
+++ b/tests/DocumentationFormsTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Html;
 use ipl\Html\Form;
 use ipl\Html\FormElement\TextElement;
 use ipl\Html\Html;
+use ipl\Html\Test\TestCase;
 
 class DocumentationFormsTest extends TestCase
 {

--- a/tests/DocumentationQuickStartTest.php
+++ b/tests/DocumentationQuickStartTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\Html;
+use ipl\Html\Test\TestCase;
 
 class DocumentationQuickStartTest extends TestCase
 {

--- a/tests/DocumentationTablesTest.php
+++ b/tests/DocumentationTablesTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\Table;
+use ipl\Html\Test\TestCase;
 
 class DocumentationTablesTest extends TestCase
 {

--- a/tests/FormDecorator/DecorationResultsTest.php
+++ b/tests/FormDecorator/DecorationResultsTest.php
@@ -5,7 +5,7 @@ namespace ipl\Tests\Html\FormDecorator;
 use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\Transformation;
 use ipl\Html\Html;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class DecorationResultsTest extends TestCase
 {

--- a/tests/FormDecorator/DecoratorChainTest.php
+++ b/tests/FormDecorator/DecoratorChainTest.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 use ipl\Html\FormDecoration\DecoratorChain;
 use ipl\Html\Contract\FormElementDecoration;
 use ipl\Html\HtmlDocument;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use ValueError;
 
 class DecoratorChainTest extends TestCase

--- a/tests/FormDecorator/DescriptionDecoratorTest.php
+++ b/tests/FormDecorator/DescriptionDecoratorTest.php
@@ -7,7 +7,7 @@ use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\DescriptionDecorator;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class DescriptionDecoratorTest extends TestCase
 {

--- a/tests/FormDecorator/ErrorsDecoratorTest.php
+++ b/tests/FormDecorator/ErrorsDecoratorTest.php
@@ -6,7 +6,7 @@ use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\ErrorsDecorator;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class ErrorsDecoratorTest extends TestCase
 {

--- a/tests/FormDecorator/FieldsetDecoratorTest.php
+++ b/tests/FormDecorator/FieldsetDecoratorTest.php
@@ -7,7 +7,7 @@ use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\FieldsetDecorator;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class FieldsetDecoratorTest extends TestCase
 {

--- a/tests/FormDecorator/FormDecorationResultTest.php
+++ b/tests/FormDecorator/FormDecorationResultTest.php
@@ -5,7 +5,7 @@ namespace ipl\Tests\Html\FormDecorator;
 use ipl\Html\Form;
 use ipl\Html\FormDecoration\FormDecorationResult;
 use ipl\Html\Html;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class FormDecorationResultTest extends TestCase
 {

--- a/tests/FormDecorator/FormDecorationTest.php
+++ b/tests/FormDecorator/FormDecorationTest.php
@@ -9,7 +9,7 @@ use ipl\Html\Contract\FormElement;
 use ipl\Html\Contract\FormElementDecoration;
 use ipl\Html\FormDecoration\Transformation;
 use ipl\Html\Html;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class FormDecorationTest extends TestCase
 {

--- a/tests/FormDecorator/FormElementDecorationTest.php
+++ b/tests/FormDecorator/FormElementDecorationTest.php
@@ -4,7 +4,7 @@ namespace ipl\Tests\Html\FormDecorator;
 
 use ipl\Html\Form;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use ipl\Tests\Html\TestDummy\SimpleFormElementDecorator;
 use RuntimeException;
 

--- a/tests/FormDecorator/HtmlTagDecoratorTest.php
+++ b/tests/FormDecorator/HtmlTagDecoratorTest.php
@@ -8,7 +8,7 @@ use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\HtmlTagDecorator;
 use ipl\Html\FormDecoration\Transformation;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use RuntimeException;
 
 class HtmlTagDecoratorTest extends TestCase

--- a/tests/FormDecorator/LabelDecoratorTest.php
+++ b/tests/FormDecorator/LabelDecoratorTest.php
@@ -9,7 +9,7 @@ use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\SubmitButtonElement;
 use ipl\Html\FormElement\SubmitElement;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class LabelDecoratorTest extends TestCase
 {

--- a/tests/FormElement/CheckboxElementTest.php
+++ b/tests/FormElement/CheckboxElementTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\FormElement\CheckboxElement;
+use ipl\Html\Test\TestCase;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
 

--- a/tests/FormElement/FieldsetElementTest.php
+++ b/tests/FormElement/FieldsetElementTest.php
@@ -7,7 +7,7 @@ use ipl\Html\FormDecorator\DivDecorator;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use ipl\Tests\Html\TestDummy\SimpleFormElementDecorator;
 use ipl\Validator\CallbackValidator;
 use LogicException;

--- a/tests/FormElement/FileElementTest.php
+++ b/tests/FormElement/FileElementTest.php
@@ -11,7 +11,7 @@ use ipl\Html\FormElement\FileElement;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
 use ipl\Tests\Html\Lib\FileElementWithAdjustableConfig;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use Psr\Http\Message\StreamInterface;
 
 class FileElementTest extends TestCase

--- a/tests/FormElement/FormElementValidationTest.php
+++ b/tests/FormElement/FormElementValidationTest.php
@@ -7,7 +7,7 @@ use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\TextElement;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use ipl\Validator\CallbackValidator;
 
 class FormElementValidationTest extends TestCase

--- a/tests/FormElement/LocalDateTimeElementTest.php
+++ b/tests/FormElement/LocalDateTimeElementTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use DateTime;
 use ipl\Html\FormElement\LocalDateTimeElement;
+use ipl\Html\Test\TestCase;
 
 class LocalDateTimeElementTest extends TestCase
 {

--- a/tests/FormElement/RadioElementTest.php
+++ b/tests/FormElement/RadioElementTest.php
@@ -9,7 +9,7 @@ use ipl\Html\FormElement\RadioElement;
 use ipl\Html\FormElement\RadioOption;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class RadioElementTest extends TestCase
 {

--- a/tests/FormElement/SelectElementTest.php
+++ b/tests/FormElement/SelectElementTest.php
@@ -7,7 +7,7 @@ use ipl\Html\FormElement\SelectElement;
 use ipl\Html\FormElement\SelectOption;
 use ipl\I18n\NoopTranslator;
 use ipl\I18n\StaticTranslator;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 use UnexpectedValueException;
 
 class SelectElementTest extends TestCase

--- a/tests/FormElement/SelectOptionTest.php
+++ b/tests/FormElement/SelectOptionTest.php
@@ -4,7 +4,7 @@ namespace ipl\Tests\Html\FormElement;
 
 use ipl\Html\FormElement\SelectElement;
 use ipl\Html\FormElement\SelectOption;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class SelectOptionTest extends TestCase
 {

--- a/tests/FormElement/SubmitButtonElementTest.php
+++ b/tests/FormElement/SubmitButtonElementTest.php
@@ -4,7 +4,7 @@ namespace ipl\Tests\Html\FormElement;
 
 use ipl\Html\Form;
 use ipl\Html\FormElement\SubmitButtonElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class SubmitButtonElementTest extends TestCase
 {

--- a/tests/FormElement/TextElementTest.php
+++ b/tests/FormElement/TextElementTest.php
@@ -4,7 +4,7 @@ namespace ipl\Tests\Html\FormElement;
 
 use ipl\Html\Attributes;
 use ipl\Html\FormElement\TextElement;
-use ipl\Tests\Html\TestCase;
+use ipl\Html\Test\TestCase;
 
 class TextElementTest extends TestCase
 {

--- a/tests/FormElementDecoratorTest.php
+++ b/tests/FormElementDecoratorTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\Form;
+use ipl\Html\Test\TestCase;
 use ipl\Tests\Html\TestDummy\PositionedFormElementDecorator;
 use ipl\Tests\Html\TestDummy\SimpleFormElementDecorator;
 use ipl\Tests\Html\TestDummy\WithinContainerFormElementDecorator;

--- a/tests/FormElementsTest.php
+++ b/tests/FormElementsTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use ipl\Html\Form;
 use ipl\Html\FormElement\FormElements;
+use ipl\Html\Test\TestCase;
 
 class FormElementsTest extends TestCase
 {

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use ipl\Html\Form;
 use ipl\Html\FormElement\BaseFormElement;
+use ipl\Html\Test\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 
 class FormTest extends TestCase

--- a/tests/FormattedStringTest.php
+++ b/tests/FormattedStringTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use ipl\Html\FormattedString;
 use ipl\Html\Html;
+use ipl\Html\Test\TestCase;
 use ipl\Tests\Html\TestDummy\ObjectThatCanBeCastedToString;
 
 class FormattedStringTest extends TestCase

--- a/tests/HtmlDocumentTest.php
+++ b/tests/HtmlDocumentTest.php
@@ -5,6 +5,7 @@ namespace ipl\Tests\Html;
 use ipl\Html\BaseHtmlElement;
 use ipl\Html\Html as h;
 use ipl\Html\HtmlDocument;
+use ipl\Html\Test\TestCase;
 use ipl\Tests\Html\TestDummy\AddsContentDuringAssemble;
 use ipl\Tests\Html\TestDummy\AddsWrapperDuringAssemble;
 use ipl\Tests\Html\TestDummy\IterableElement;

--- a/tests/HtmlStringTest.php
+++ b/tests/HtmlStringTest.php
@@ -3,6 +3,7 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\HtmlString;
+use ipl\Html\Test\TestCase;
 use ipl\Html\Text;
 
 class HtmlStringTest extends TestCase

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -4,6 +4,7 @@ namespace ipl\Tests\Html;
 
 use InvalidArgumentException;
 use ipl\Html\Html;
+use ipl\Html\Test\TestCase;
 
 class HtmlTest extends TestCase
 {

--- a/tests/TemplateStringTest.php
+++ b/tests/TemplateStringTest.php
@@ -3,8 +3,9 @@
 namespace ipl\Tests\Html;
 
 use Exception;
-use ipl\Html\TemplateString;
 use ipl\Html\Html;
+use ipl\Html\TemplateString;
+use ipl\Html\Test\TestCase;
 
 class TemplateStringTest extends TestCase
 {


### PR DESCRIPTION
Expose `TestCase` under the `ipl\Html\Test` namespace so downstream
packages can extend or use it in their own test suites without
adjusting their `composer.json`.

Drop the pre-namespace `PHPUnit_Util_XML` compat shim that targeted
PHPUnit 4.x, add native parameter and return types, and align
`assertHtml`'s parameter names with the conventional `$expected` /
`$actual` pair.