### PR TITLE
Preserve `checked` state of `disabled` checkbox on submit

### DIFF
--- a/src/FormElement/CheckboxElement.php
+++ b/src/FormElement/CheckboxElement.php
@@ -119,7 +119,11 @@ class CheckboxElement extends InputElement
     {
         $html = parent::renderUnwrapped();
 
-        return (new HiddenElement($this->getValueOfNameAttribute(), ['value' => $this->getUncheckedValue()])) . $html;
+        $value = $this->getAttribute('disabled')->getValue() && $this->isChecked()
+            ? $this->getCheckedValue()
+            : $this->getUncheckedValue();
+
+        return (new HiddenElement($this->getValueOfNameAttribute(), ['value' => $value])) . $html;
     }
 
     /**

--- a/tests/FormElement/CheckboxElementTest.php
+++ b/tests/FormElement/CheckboxElementTest.php
@@ -115,6 +115,32 @@ class CheckboxElementTest extends TestCase
         );
     }
 
+    public function testDisabledCheckedCheckboxRendersHiddenElementWithCheckedValue()
+    {
+        $checkbox = new CheckboxElement('test');
+        $checkbox->setChecked(true);
+        $checkbox->getAttributes()->set('disabled', true);
+
+        $this->assertHtml(
+            '<input type="hidden" name="test" value="y">'
+            . '<input checked="checked" disabled="disabled" type="checkbox" name="test" value="y">',
+            $checkbox
+        );
+    }
+
+    public function testDisabledUncheckedCheckboxRendersHiddenElementWithUncheckedValue()
+    {
+        $checkbox = new CheckboxElement('test');
+        $checkbox->setChecked(false);
+        $checkbox->getAttributes()->set('disabled', true);
+
+        $this->assertHtml(
+            '<input type="hidden" name="test" value="n">'
+            . '<input disabled="disabled" type="checkbox" name="test" value="y">',
+            $checkbox
+        );
+    }
+
     public function testCheckboxNotValidIfRequiredAndUnchecked()
     {
         $checkbox = new CheckboxElement('test');


### PR DESCRIPTION
Browsers do not submit `disabled` inputs. Since `CheckboxElement`'s `hidden` fallback element always used the `unchecked` value, a `checked` but `disabled` checkbox would appear `unchecked` on the next submit.
Fix `renderUnwrapped()` to use the `checked` value in the `hidden` element when the checkbox is `checked` and `disabled`, preserving its state across submissions.

fixes #192