### PR TITLE
Revert form element escaping

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -66,6 +66,26 @@ class Form extends BaseHtmlElement implements Contract\Form, Contract\FormElemen
         return $value === null || $value === [] || (is_string($value) && trim($value) === '');
     }
 
+    /**
+     * Return the given string unchanged.
+     *
+     * @param string $string
+     * @param bool $escapeBrackets
+     *
+     * @return string
+     * @deprecated Escaping element names must be explicitly done. This method does not escape
+     *             anymore and will be removed in a future version.
+     */
+    public static function escapeReservedChars(string $string, bool $escapeBrackets = true): string
+    {
+        trigger_error(sprintf(
+            '%s is deprecated. Escaping element names must be explicitly done.',
+            __METHOD__
+        ), E_USER_DEPRECATED);
+
+        return $string;
+    }
+
     public function getAction()
     {
         return $this->action;

--- a/src/Form.php
+++ b/src/Form.php
@@ -66,40 +66,6 @@ class Form extends BaseHtmlElement implements Contract\Form, Contract\FormElemen
         return $value === null || $value === [] || (is_string($value) && trim($value) === '');
     }
 
-    /**
-     * Escape reserved chars in the given string
-     *
-     * The characters '.', ' ' and optionally brackets are converted to unused control characters
-     * File Separator: ␜, Group Separator: ␝, Record Separator: ␝, and Unit Separator: ␟ respectively.
-     *
-     * This is done because:
-     * PHP converts dots and spaces in form element names to underscores by default in the request data.
-     * For example, <input name="a.b" /> becomes $_REQUEST["a_b"].
-     *
-     * And if an external variable name begins with a valid array syntax, trailing characters are silently ignored.
-     * For example, <input name="foo[bar]baz"> becomes $_REQUEST['foo']['bar'].
-     * See https://www.php.net/manual/en/language.variables.external.php
-     *
-     * @param string $string The string to escape
-     * @param bool   $escapeBrackets Whether to escape brackets
-     *
-     * @return string
-     */
-    public static function escapeReservedChars(string $string, bool $escapeBrackets = true): string
-    {
-        $escapeMap = [
-            '.' => chr(28), // File Separator
-            ' ' => chr(29)  // Group Separator
-        ];
-
-        if ($escapeBrackets) {
-            $escapeMap['['] = chr(30); // Record Separator
-            $escapeMap[']'] = chr(31); // Unit Separator
-        }
-
-        return strtr($string, $escapeMap);
-    }
-
     public function getAction()
     {
         return $this->action;

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -130,15 +130,8 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     {
         $this->name = $name;
 
-        // TODO: phpdoc always expressed that only strings are accepted, but some usages passed null despite that.
-        //       The isset check is only a compatibility measure to not break BC. Remove once the interface actually
-        //       requires a string. And don't ever dare to allow null (`?string`) due to this check!!!1
-        if (isset($this->name)) {
-            // Name is always escaped
-            $this->escapedName = Form::escapeReservedChars($name);
-        } else {
-            $this->escapedName = '';
-        }
+        // Name is always escaped
+        $this->escapedName = Form::escapeReservedChars($name);
 
         return $this;
     }

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -36,9 +36,6 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     /** @var string Name of the element */
     protected $name;
 
-    /** @var string Escaped name of the element */
-    protected string $escapedName;
-
     /** @var bool Whether the element is ignored */
     protected $ignored = false;
 
@@ -130,9 +127,6 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     {
         $this->name = $name;
 
-        // Name is always escaped
-        $this->escapedName = Form::escapeReservedChars($name);
-
         return $this;
     }
 
@@ -153,16 +147,6 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
         $this->ignored = (bool) $ignored;
 
         return $this;
-    }
-
-    /**
-     * Get the escaped name of the element
-     *
-     * @return string
-     */
-    public function getEscapedName(): string
-    {
-        return $this->escapedName;
     }
 
     public function isRequired()
@@ -317,7 +301,7 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
      */
     public function getNameAttribute()
     {
-        return $this->getEscapedName();
+        return $this->getName();
     }
 
     /**
@@ -413,7 +397,7 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
             return $name;
         }
 
-        return $this->getEscapedName();
+        return $this->getName();
     }
 
     public function getDecorators(): DecoratorChain

--- a/src/FormElement/FieldsetElement.php
+++ b/src/FormElement/FieldsetElement.php
@@ -116,14 +116,6 @@ class FieldsetElement extends BaseFormElement implements \ipl\Html\Contract\Form
                 $multiple = $element->isMultiple();
             }
 
-            // This check is required as the getEscapedName method is not implemented in
-            // the FormElement interface
-            if ($element instanceof BaseFormElement) {
-                $name = $element->getEscapedName();
-            } else {
-                $name = $element->getName();
-            }
-
             /**
              * We don't change the {@see BaseFormElement::$name} property of the element,
              * otherwise methods like {@see FormElements::populate() and {@see FormElements::getElement()} would fail,
@@ -132,7 +124,7 @@ class FieldsetElement extends BaseFormElement implements \ipl\Html\Contract\Form
             return sprintf(
                 '%s[%s]%s',
                 $this->getValueOfNameAttribute(),
-                $name,
+                $element->getName(),
                 $multiple ? '[]' : ''
             );
         });

--- a/src/FormElement/FileElement.php
+++ b/src/FormElement/FileElement.php
@@ -93,7 +93,7 @@ class FileElement extends InputElement
 
     public function getNameAttribute()
     {
-        $name = $this->getEscapedName();
+        $name = $this->getName();
 
         return $this->isMultiple() ? ($name . '[]') : $name;
     }
@@ -260,12 +260,12 @@ class FileElement extends InputElement
             $form->setAttribute('enctype', 'multipart/form-data');
         }
 
-        $chosenFiles = (array) $form->getPopulatedValue('chosen_file_' . $this->getEscapedName(), []);
+        $chosenFiles = (array) $form->getPopulatedValue('chosen_file_' . $this->getName(), []);
         foreach ($chosenFiles as $chosenFile) {
             $this->files[$chosenFile] = null;
         }
 
-        $this->filesToRemove = (array) $form->getPopulatedValue('remove_file_' . $this->getEscapedName(), []);
+        $this->filesToRemove = (array) $form->getPopulatedValue('remove_file_' . $this->getName(), []);
     }
 
     protected function addDefaultValidators(ValidatorChain $chain): void

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -230,14 +230,6 @@ trait FormElements
     {
         $name = $element->getName();
 
-        // This check is required as the getEscapedName method is not implemented in
-        // the FormElement interface
-        if ($element instanceof BaseFormElement) {
-            $escapedName = $element->getEscapedName();
-        } else {
-            $escapedName = $name;
-        }
-
         if ($name === null) {
             throw new InvalidArgumentException(sprintf(
                 '%s expects the element to provide a name',
@@ -247,13 +239,11 @@ trait FormElements
 
         $this->elements[$name] = $element;
 
-        if (array_key_exists($escapedName, $this->populatedValues)) {
-            $element->setValue(
-                $this->populatedValues[$escapedName][count($this->populatedValues[$escapedName]) - 1]
-            );
+        if (array_key_exists($name, $this->populatedValues)) {
+            $element->setValue($this->populatedValues[$name][count($this->populatedValues[$name]) - 1]);
 
             if ($element instanceof ValueCandidates) {
-                $element->setValueCandidates($this->populatedValues[$escapedName]);
+                $element->setValueCandidates($this->populatedValues[$name]);
             }
         }
 
@@ -369,7 +359,7 @@ trait FormElements
     public function populate($values)
     {
         foreach ($values as $name => $value) {
-            $this->populatedValues[Form::escapeReservedChars($name)][] = $value;
+            $this->populatedValues[$name][] = $value;
             if ($this->hasElement($name)) {
                 $this->getElement($name)->setValue($value);
             }
@@ -390,7 +380,6 @@ trait FormElements
      */
     public function getPopulatedValue($name, $default = null)
     {
-        $name = Form::escapeReservedChars($name);
         return isset($this->populatedValues[$name])
             ? $this->populatedValues[$name][count($this->populatedValues[$name]) - 1]
             : $default;
@@ -405,7 +394,6 @@ trait FormElements
      */
     public function clearPopulatedValue($name)
     {
-        $name = Form::escapeReservedChars($name);
         if (isset($this->populatedValues[$name])) {
             unset($this->populatedValues[$name]);
         }

--- a/src/FormElement/SelectElement.php
+++ b/src/FormElement/SelectElement.php
@@ -110,7 +110,7 @@ class SelectElement extends BaseFormElement
 
     public function getNameAttribute()
     {
-        $name = $this->getEscapedName();
+        $name = $this->getName();
 
         return $this->isMultiple() ? ($name . '[]') : $name;
     }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -3,7 +3,6 @@
 namespace ipl\Tests\Html;
 
 use ipl\Html\Form;
-use ipl\Html\FormElement\BaseFormElement;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\Test\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
@@ -52,18 +51,6 @@ class FormTest extends TestCase
         $form->handleRequest($request2);
     }
 
-    public function testEscapeReservedChars(): void
-    {
-        // Reserved chars '.', ' ', '[' and ']' are escaped
-        $this->assertSame(Form::escapeReservedChars('foo.bar'), 'foo' . chr(28) . 'bar');
-        $this->assertSame(Form::escapeReservedChars('foo bar'), 'foo' . chr(29) . 'bar');
-        $this->assertSame(Form::escapeReservedChars('foo[bar]'), 'foo' . chr(30) . 'bar' . chr(31));
-
-        // The string remains the same
-        $this->assertSame(Form::escapeReservedChars('foo[bar]', false), 'foo[bar]');
-        $this->assertSame(Form::escapeReservedChars('foo-bar123'), 'foo-bar123');
-    }
-
     public function testValidatePartialOnlyValidatesFieldsetChildrenWithAValue(): void
     {
         $fieldset = (new FieldsetElement('set'))
@@ -102,39 +89,5 @@ class FormTest extends TestCase
             $form->getElement('outer')->getElement('inner')->getElement('deep')->isValid(),
             'Nested fieldset child with a value is not validated during partial validation'
         );
-    }
-
-    public function testFormElementsWithReservedCharsInName(): void
-    {
-        $form = new Form();
-
-        // Test that the element name gets escaped as soon as the name is set
-        /** @var BaseFormElement $el1 */
-        $el1 = $form->createElement('text', 'foo.bar');
-        $this->assertSame('foo' . chr(28) . 'bar', $el1->getEscapedName());
-
-        /** @var BaseFormElement $el2 */
-        $el2 = $form->createElement('text', 'foo[bar]');
-        $this->assertSame('foo' . chr(30) . 'bar' . chr(31), $el2->getEscapedName());
-
-        $el2->setName('foo bar');
-        $this->assertSame('foo' . chr(29) . 'bar', $el2->getEscapedName());
-
-        $form->registerElement($el1);
-        $form->registerElement($el2);
-
-        // Test that the element name is escaped when rendered
-        $this->assertHtml('<input name="foo' . chr(28) . 'bar" type="text" />', $form->getElement('foo.bar'));
-        $this->assertHtml('<input name="foo' . chr(29) . 'bar" type="text" />', $form->getElement('foo bar'));
-
-        // Test for data population; Initial data is not escaped
-        $form->populate(['foo.bar' => 'foo', 'foo bar' => 'bar']);
-        $this->assertSame('foo', $form->getPopulatedValue('foo.bar'));
-        $this->assertSame('bar', $form->getPopulatedValue('foo bar'));
-
-        // Test for data population; The POST data contains the escaped chars
-        $form->populate(['foo' . chr(28) . 'bar' => 'foo1', 'foo' . chr(29) . 'bar' => 'bar1']);
-        $this->assertSame('foo1', $form->getPopulatedValue('foo.bar'));
-        $this->assertSame('bar1', $form->getPopulatedValue('foo bar'));
     }
 }


### PR DESCRIPTION
It turned out to be rather problematic to implicitly escape every form element name as we cannot guarantee that element names are not programmatically constructed already.

Examples:

`\ipl\Html\FormElement\CheckboxElement` renders a hidden element representing its unchecked state and uses `getValueOfNameAttribute` to define the name for it. This is done to support fieldsets containing a checkbox element. Though, fieldsets require special element names and hence this results in an constructed name with brackets being used as literal and hence the hidden element escapes it.

Another case is when an element with an escaped name is also capable of auto-submitting the form. Icinga Web will transmit the name of such an element in a special http request header value and since we used invisible control characters to escape form element names, this resulted in invalid header values.

--

It's for these reasons that we decided to drop support for implicit form element name escaping again and require form implementors to safe-guard themselves by explicitly escaping their names. `Form::escapeReservedChars()` has been deprecated and triggers a deprecation notice if used from now on.