### PR TITLE
TestCase: suppress DOMDocument HTML5 tag errors

### DIFF
--- a/src/Test/TestCase.php
+++ b/src/Test/TestCase.php
@@ -24,9 +24,9 @@ abstract class TestCase extends BaseTestCase
         $actualHtml = $actual->render();
 
         $expectedDom = new DOMDocument();
-        $this->assertTrue($expectedDom->loadHTML($expectedHtml), 'Expected HTML is not valid');
+        $this->assertTrue($expectedDom->loadHTML($expectedHtml, LIBXML_NOERROR), 'Expected HTML is not valid');
         $actualDom = new DOMDocument();
-        $this->assertTrue($actualDom->loadHTML($actualHtml), 'Actual HTML is not valid');
+        $this->assertTrue($actualDom->loadHTML($actualHtml, LIBXML_NOERROR), 'Actual HTML is not valid');
 
         $this->assertEquals($expectedDom, $actualDom);
     }


### PR DESCRIPTION
Use option `LIBXML_NOERROR` for `loadHTML()` to suppress invalid tag errors caused by HTML5 elements (e.g. `<time>`) that libxml2 does not recognize.

see: https://www.php.net/manual/en/domdocument.loadhtml.php