### PR TITLE
Add `pleaseChoose` option to `SelectElement`

### DIFF
--- a/src/FormElement/SelectElement.php
+++ b/src/FormElement/SelectElement.php
@@ -28,6 +28,26 @@ class SelectElement extends BaseFormElement
     /** @var array|string|null */
     protected $value;
 
+    /** @var bool Whether to prepend a disabled "Please choose" option */
+    protected bool $pleaseChoose = false;
+
+    /**
+     * Set whether to prepend a disabled "Please choose" option
+     *
+     * When enabled, a disabled option with an empty value and the label
+     * " - Please choose - " is prepended to the rendered options.
+     *
+     * @param bool $pleaseChoose
+     *
+     * @return $this
+     */
+    public function setPleaseChoose(bool $pleaseChoose): self
+    {
+        $this->pleaseChoose = $pleaseChoose;
+
+        return $this;
+    }
+
     /**
      * Get the option with specified value
      *
@@ -206,6 +226,14 @@ class SelectElement extends BaseFormElement
 
     protected function assemble()
     {
+        if ($this->pleaseChoose && ! isset($this->optionContent[''])) {
+            $option = (new SelectOption('', sprintf(' - %s - ', $this->translate('Please choose'))))
+                ->setAttribute('disabled', true);
+            $option->getAttributes()->registerAttributeCallback('selected', fn() => $this->isSelectedOption(''));
+            $this->options[''] = $option;
+            $this->addHtml($option);
+        }
+
         $this->addHtml(...array_values($this->optionContent));
     }
 
@@ -224,6 +252,8 @@ class SelectElement extends BaseFormElement
             null,
             [$this, 'setDisabledOptions']
         );
+
+        $attributes->registerAttributeCallback('pleaseChoose', null, $this->setPleaseChoose(...));
 
         // ZF1 compatibility:
         $this->getAttributes()->registerAttributeCallback(

--- a/tests/FormElement/SelectElementTest.php
+++ b/tests/FormElement/SelectElementTest.php
@@ -737,4 +737,78 @@ HTML;
         $this->assertInstanceOf(SelectOption::class, $select->getOption('foo'));
         $this->assertInstanceOf(SelectOption::class, $select->getOption('bar'));
     }
+
+    public function testPleaseChoosePrependsDisabledOption()
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+
+        $select = new SelectElement('theme', [
+            'options'      => ['light' => 'Light', 'dark' => 'Dark'],
+            'pleaseChoose' => true,
+        ]);
+
+        $html = <<<'HTML'
+<select name="theme">
+    <option value="" selected disabled> - Please choose - </option>
+    <option value="light">Light</option>
+    <option value="dark">Dark</option>
+</select>
+HTML;
+
+        $this->assertHtml($html, $select);
+    }
+
+    public function testPleaseChooseOptionIsDeselectedWhenValueIsSet()
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+
+        $select = new SelectElement('theme', [
+            'options'      => ['light' => 'Light', 'dark' => 'Dark'],
+            'value'        => 'light',
+            'pleaseChoose' => true,
+        ]);
+
+        $html = <<<'HTML'
+<select name="theme">
+    <option value="" disabled> - Please choose - </option>
+    <option value="light" selected>Light</option>
+    <option value="dark">Dark</option>
+</select>
+HTML;
+
+        $this->assertHtml($html, $select);
+    }
+
+    public function testPleaseChooseDoesNotOverrideExistingEmptyOption()
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+
+        $select = new SelectElement('theme', [
+            'options'      => ['' => 'Custom placeholder', 'light' => 'Light'],
+            'pleaseChoose' => true,
+        ]);
+
+        $html = <<<'HTML'
+<select name="theme">
+    <option value="" selected>Custom placeholder</option>
+    <option value="light">Light</option>
+</select>
+HTML;
+
+        $this->assertHtml($html, $select);
+    }
+
+    public function testPleaseChooseCanBeSetViaFluentApi()
+    {
+        StaticTranslator::$instance = new NoopTranslator();
+
+        $select = (new SelectElement('theme'))
+            ->setOptions(['light' => 'Light', 'dark' => 'Dark'])
+            ->setPleaseChoose(true);
+
+        $this->assertTrue($select->getOption('') === null); // not yet assembled
+        $select->render();
+        $this->assertInstanceOf(SelectOption::class, $select->getOption(''));
+        $this->assertTrue($select->getOption('')->getAttributes()->get('disabled')->getValue());
+    }
 }


### PR DESCRIPTION
Add a `pleaseChoose` option to `SelectElement` that prepends the placeholder automatically:

```php
(new SelectElement('type'))
    ->setOptions($types)
    ->setPleaseChoose(true);
```

Or declaratively:

```php
[
    'type'         => 'select',
    'options'      => $types,
    'pleaseChoose' => true,
]
```

When enabled and no `''` option does exist, the element prepends `['' => sprintf(' - %s - ', t('Please choose'))]` to the rendered options and marks it as disabled, so callers do not need to handle either step.

resolve #199 