### PR TITLE
Labels without escaping

### DIFF
--- a/src/Contract/FormElement.php
+++ b/src/Contract/FormElement.php
@@ -4,6 +4,7 @@ namespace ipl\Html\Contract;
 
 use ipl\Html\Attributes;
 use ipl\Html\Form;
+use ipl\Html\ValidHtml;
 
 /**
  * Representation of form elements
@@ -38,7 +39,7 @@ interface FormElement extends Wrappable
     /**
      * Get the label for the element, if any
      *
-     * @return string|null
+     * @return string|ValidHtml|null
      */
     public function getLabel();
 

--- a/src/FormDecoration/FieldsetDecorator.php
+++ b/src/FormDecoration/FieldsetDecorator.php
@@ -9,6 +9,7 @@ use ipl\Html\Contract\HtmlElementInterface;
 use ipl\Html\Contract\MutableHtml;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
+use ipl\Html\ValidHtml;
 
 /**
  * Decorates the fieldset of the form element
@@ -30,7 +31,9 @@ class FieldsetDecorator implements FormElementDecoration
 
         $label = $formElement->getLabel();
         if ($label !== null) {
-            $formElement->prependHtml(new HtmlElement('legend', null, Text::create($label)));
+            $formElement->prependHtml(
+                new HtmlElement('legend', null, $label instanceof ValidHtml ? $label : new Text($label))
+            );
         }
     }
 }

--- a/src/FormDecoration/LabelDecorator.php
+++ b/src/FormDecoration/LabelDecorator.php
@@ -98,7 +98,7 @@ class LabelDecorator implements FormElementDecoration, DecoratorOptionsInterface
             return null;
         }
 
-        return new HtmlElement('label', content: new Text($label));
+        return new HtmlElement('label', content: $label instanceof ValidHtml ? $label : new Text($label));
     }
 
     protected function registerAttributeCallbacks(Attributes $attributes): void

--- a/src/FormDecorator/DivDecorator.php
+++ b/src/FormDecorator/DivDecorator.php
@@ -13,6 +13,7 @@ use ipl\Html\FormElement\HiddenElement;
 use ipl\Html\Html;
 use ipl\Html\HtmlElement;
 use ipl\Html\Text;
+use ipl\Html\ValidHtml;
 
 /**
  * Form element decorator based on div elements
@@ -116,7 +117,7 @@ class DivDecorator extends BaseHtmlElement implements FormElementDecorator
 
         if ($label !== null) {
             if ($this->formElement instanceof FieldsetElement) {
-                return new HtmlElement('legend', null, Text::create($label));
+                return new HtmlElement('legend', null, $label instanceof ValidHtml ? $label : new Text($label));
             } else {
                 $attributes = null;
                 if ($this->formElement->getAttributes()->has('id')) {

--- a/src/FormElement/BaseFormElement.php
+++ b/src/FormElement/BaseFormElement.php
@@ -12,6 +12,7 @@ use ipl\Html\Contract\ValueCandidates;
 use ipl\Html\Form;
 use ipl\Html\FormDecoration\DecoratorChain;
 use ipl\Html\FormDecoration\FormElementDecorationResult;
+use ipl\Html\ValidHtml;
 use ipl\I18n\Translation;
 use ipl\Stdlib\Messages;
 use ipl\Validator\ValidatorChain;
@@ -30,7 +31,7 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     /** @var string Description of the element */
     protected $description;
 
-    /** @var string Label of the element */
+    /** @var string|ValidHtml|null Label of the element */
     protected $label;
 
     /** @var string Name of the element */
@@ -100,7 +101,7 @@ abstract class BaseFormElement extends BaseHtmlElement implements FormElement, V
     /**
      * Set the label of the element
      *
-     * @param string $label
+     * @param string|ValidHtml $label
      *
      * @return $this
      */

--- a/src/FormElement/SubmitElement.php
+++ b/src/FormElement/SubmitElement.php
@@ -11,6 +11,16 @@ class SubmitElement extends InputElement implements FormSubmitElement
 
     protected $buttonLabel;
 
+    /**
+     * Set the label of the element
+     *
+     * Unlike other elements, the label populates the element's `value` attribute
+     * and is compared against the submitted value, so it must be a plain string.
+     *
+     * @param string $label
+     *
+     * @return $this
+     */
     public function setLabel($label)
     {
         $this->buttonLabel = $label;

--- a/tests/FormDecorator/FieldsetDecoratorTest.php
+++ b/tests/FormDecorator/FieldsetDecoratorTest.php
@@ -7,7 +7,9 @@ use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\FieldsetDecorator;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\TextElement;
+use ipl\Html\HtmlString;
 use ipl\Html\Test\TestCase;
+use ipl\Html\ValidHtml;
 
 class FieldsetDecoratorTest extends TestCase
 {
@@ -90,6 +92,56 @@ HTML;
         $this->decorator->decorateFormElement($results, new FieldsetElement('test', ['label' => 'Testing']));
 
         $this->assertEmpty($results->assemble()->render());
+    }
+
+    public function testStringLabelIsEscaped(): void
+    {
+        $fieldset = new FieldsetElement('test');
+        $fieldset->setLabel('<em>italic</em>');
+        $this->decorator->decorateFormElement(new FormElementDecorationResult(), $fieldset);
+
+        $html = <<<HTML
+<fieldset name="test">
+  <legend>&lt;em&gt;italic&lt;/em&gt;</legend>
+</fieldset>
+HTML;
+
+        $this->assertHtml($html, $fieldset);
+    }
+
+    public function testHtmlStringLabelIsRenderedAsIs(): void
+    {
+        $fieldset = new FieldsetElement('test');
+        $fieldset->setLabel(new HtmlString('<em>italic</em>'));
+        $this->decorator->decorateFormElement(new FormElementDecorationResult(), $fieldset);
+
+        $html = <<<HTML
+<fieldset name="test">
+  <legend><em>italic</em></legend>
+</fieldset>
+HTML;
+
+        $this->assertHtml($html, $fieldset);
+    }
+
+    public function testRenderOnlyValidHtmlLabelIsRenderedAsIs(): void
+    {
+        $fieldset = new FieldsetElement('test');
+        $fieldset->setLabel(new class implements ValidHtml {
+            public function render(): string
+            {
+                return '<em>italic</em>';
+            }
+        });
+        $this->decorator->decorateFormElement(new FormElementDecorationResult(), $fieldset);
+
+        $html = <<<HTML
+<fieldset name="test">
+  <legend><em>italic</em></legend>
+</fieldset>
+HTML;
+
+        $this->assertHtml($html, $fieldset);
     }
 
     public function testNonHtmlFormElementsAreIgnored(): void

--- a/tests/FormDecorator/LabelDecoratorTest.php
+++ b/tests/FormDecorator/LabelDecoratorTest.php
@@ -5,11 +5,13 @@ namespace ipl\Tests\Html\FormDecorator;
 use ipl\Html\Contract\FormElement;
 use ipl\Html\FormDecoration\FormElementDecorationResult;
 use ipl\Html\FormDecoration\LabelDecorator;
+use ipl\Html\HtmlString;
 use ipl\Html\FormElement\FieldsetElement;
 use ipl\Html\FormElement\SubmitButtonElement;
 use ipl\Html\FormElement\SubmitElement;
 use ipl\Html\FormElement\TextElement;
 use ipl\Html\Test\TestCase;
+use ipl\Html\ValidHtml;
 
 class LabelDecoratorTest extends TestCase
 {
@@ -109,6 +111,50 @@ class LabelDecoratorTest extends TestCase
         $this->decorator->decorateFormElement($results, new SubmitElement('test'));
 
         $this->assertSame('', $results->assemble()->render());
+    }
+
+    public function testStringLabelIsEscaped(): void
+    {
+        $results = new FormElementDecorationResult();
+        $element = new TextElement('test', ['id' => 'test-id']);
+        $element->setLabel('<em>italic</em>');
+        $this->decorator->decorateFormElement($results, $element);
+
+        $this->assertHtml(
+            '<label for="test-id" class="form-element-label">&lt;em&gt;italic&lt;/em&gt;</label>',
+            $results->assemble()
+        );
+    }
+
+    public function testValidHtmlLabelIsRenderedAsIs(): void
+    {
+        $results = new FormElementDecorationResult();
+        $element = new TextElement('test', ['id' => 'test-id']);
+        $element->setLabel(new HtmlString('<em>italic</em>'));
+        $this->decorator->decorateFormElement($results, $element);
+
+        $this->assertHtml(
+            '<label for="test-id" class="form-element-label"><em>italic</em></label>',
+            $results->assemble()
+        );
+    }
+
+    public function testRenderOnlyValidHtmlLabelIsRenderedAsIs(): void
+    {
+        $results = new FormElementDecorationResult();
+        $element = new TextElement('test', ['id' => 'test-id']);
+        $element->setLabel(new class implements ValidHtml {
+            public function render(): string
+            {
+                return '<em>italic</em>';
+            }
+        });
+        $this->decorator->decorateFormElement($results, $element);
+
+        $this->assertHtml(
+            '<label for="test-id" class="form-element-label"><em>italic</em></label>',
+            $results->assemble()
+        );
     }
 
     public function testNonHtmlFormElementsAreSupported(): void


### PR DESCRIPTION
`LabelDecorator` and `FieldsetDecorator` previously wrapped every label in `Text`, which HTML-escapes its content on render. Passing a `ValidHtml` label therefore caused its markup to be double-escaped, and passing any `ValidHtml` that does not implement `__toString()` caused a fatal error during the string coercion in `Text::setContent()`.

Both decorators now detect `ValidHtml` labels and use them directly, wrapping only plain strings in `Text`. `FieldsetDecorator` requires its own fix because fieldset elements bypass `LabelDecorator` entirely and render the legend themselves.

The `$label` property, `setLabel()`, and `getLabel()` type annotations are updated to reflect that labels may be either a plain string or a `ValidHtml` object.

Tests cover string escaping, `HtmlString` pass-through, and a render-only `ValidHtml` implementation (no `__toString()`) for both decorators.