### PR TITLE
Replace error list with individual `Callout` widgets in `onError`

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -11,6 +11,8 @@ use ipl\Html\FormDecoration\DecoratorChain;
 use ipl\Html\FormDecoration\FormDecorationResult;
 use ipl\Html\FormElement\FormElements;
 use ipl\Stdlib\Messages;
+use ipl\Web\Common\CalloutType;
+use ipl\Web\Widget\Callout;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
@@ -381,17 +383,12 @@ class Form extends BaseHtmlElement implements Contract\Form, Contract\FormElemen
 
     protected function onError()
     {
-        $errors = Html::tag('ul', ['class' => 'errors']);
         foreach ($this->getMessages() as $message) {
             if ($message instanceof Throwable) {
                 $message = $message->getMessage();
             }
 
-            $errors->addHtml(Html::tag('li', $message));
-        }
-
-        if (! $errors->isEmpty()) {
-            $this->prependHtml($errors);
+            $this->prependHtml(new Callout(CalloutType::Error, $message));
         }
     }
 


### PR DESCRIPTION
Each form error is now shown as a separate `Callout` instead of collecting all messages into a single `<ul class="errors">`. This displays the errors in a prettier way for the user.