### PR TITLE
Make `FormElements::$populatedValues` protected

### DIFF
--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -67,7 +67,7 @@ trait FormElements
     private $elements = [];
 
     /** @var array<string, array<int, mixed>> */
-    private $populatedValues = [];
+    protected $populatedValues = [];
 
     /**
      * Get the default element decorators.


### PR DESCRIPTION
This allows the form to modify `populatedValues`