### PR TITLE
Add `getPopulatedValues()` to `FormElements`

### DIFF
--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -386,13 +386,14 @@ trait FormElements
     }
 
     /**
-     * Get the populated values chain of the element specified by name
+     * Get the populated values of the element specified by name
      *
-     * Returns an empty array if there is no populated value for this element.
+     * Values are returned in population order, from earliest to latest.
+     * Returns an empty array if no value was populated for this element.
      *
      * @param string $name Element name
      *
-     * @return array
+     * @return list<mixed>
      */
     public function getPopulatedValues(string $name): array
     {

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -386,6 +386,20 @@ trait FormElements
     }
 
     /**
+     * Get the chain of populated values of the element specified by name
+     *
+     * Returns an empty array if there is no populated value for this element.
+     *
+     * @param string $name
+     *
+     * @return array
+     */
+    public function getPopulatedValues(string $name): array
+    {
+        return $this->populatedValues[$name] ?? [];
+    }
+
+    /**
      * Clear populated value of the given element
      *
      * @param string $name

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -386,7 +386,7 @@ trait FormElements
     }
 
     /**
-     * Get the chain of populated values of the element specified by name
+     * Get the populated values chain of the element specified by name
      *
      * Returns an empty array if there is no populated value for this element.
      *

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -390,7 +390,7 @@ trait FormElements
      *
      * Returns an empty array if there is no populated value for this element.
      *
-     * @param string $name
+     * @param string $name Element name
      *
      * @return array
      */

--- a/tests/FormElementsTest.php
+++ b/tests/FormElementsTest.php
@@ -8,6 +8,31 @@ use ipl\Html\Test\TestCase;
 
 class FormElementsTest extends TestCase
 {
+    public function testGetPopulatedValuesReturnsEmptyArrayForUnknownName(): void
+    {
+        $form = new Form();
+
+        $this->assertSame([], $form->getPopulatedValues('unknown'));
+    }
+
+    public function testGetPopulatedValuesReturnsSingleItemArrayAfterOnePopulate(): void
+    {
+        $form = new Form();
+        $form->populate(['name' => 'value']);
+
+        $this->assertSame(['value'], $form->getPopulatedValues('name'));
+    }
+
+    public function testGetPopulatedValuesReturnsFullChainAfterMultiplePopulates(): void
+    {
+        $form = new Form();
+        $form->populate(['name' => 'first']);
+        $form->populate(['name' => 'second']);
+        $form->populate(['name' => 'third']);
+
+        $this->assertSame(['first', 'second', 'third'], $form->getPopulatedValues('name'));
+    }
+
     public function testFormWithCustomElementLoader()
     {
         $form = $this->getFormWithCustomElementAndDecoratorLoader();


### PR DESCRIPTION
Since `getPopulatedValue()` returns only the last entry in the populated-values chain there is no way to access previously populated values. `getPopulatedValues()` exposes the full chain, defaulting to an empty array if no value was populated.