### PR TITLE
Error: default to hiding stack traces (fail closed)

### DIFF
--- a/src/Error.php
+++ b/src/Error.php
@@ -17,7 +17,7 @@ use function ipl\Stdlib\get_php_type;
 abstract class Error
 {
     /** @var bool */
-    protected static $showTraces = true;
+    protected static $showTraces = false;
 
     /**
      *


### PR DESCRIPTION
Stack traces can leak file paths, config, and other internals if a consuming application forgets to explicitly disable them in production. Defaulting to false means traces are only ever shown when a caller opts in, rather than opting out.

(As discussed offline.)