### PR TITLE
Move `isValidEvent` into `Form` and `FieldsetElement` and add `ON_ASSEMBLED` support

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -360,6 +360,18 @@ class Form extends BaseHtmlElement implements Contract\Form, Contract\FormElemen
         return $this;
     }
 
+    public function isValidEvent($event)
+    {
+        return in_array($event, [
+            Contract\Form::ON_SUBMIT,
+            Contract\Form::ON_SENT,
+            Contract\Form::ON_ERROR,
+            Contract\Form::ON_REQUEST,
+            Contract\Form::ON_VALIDATE,
+            static::ON_ELEMENT_REGISTERED,
+        ]);
+    }
+
     /**
      * Apply the form decoration
      *

--- a/src/Form.php
+++ b/src/Form.php
@@ -369,6 +369,7 @@ class Form extends BaseHtmlElement implements Contract\Form, Contract\FormElemen
             Contract\Form::ON_REQUEST,
             Contract\Form::ON_VALIDATE,
             static::ON_ELEMENT_REGISTERED,
+            static::ON_ASSEMBLED,
         ]);
     }
 

--- a/src/FormElement/FieldsetElement.php
+++ b/src/FormElement/FieldsetElement.php
@@ -110,7 +110,7 @@ class FieldsetElement extends BaseFormElement implements \ipl\Html\Contract\Form
 
     public function isValidEvent($event)
     {
-        return $event === static::ON_ELEMENT_REGISTERED;
+        return $event === static::ON_ELEMENT_REGISTERED || $event === static::ON_ASSEMBLED;
     }
 
     protected function onElementRegistered(FormElement $element)

--- a/src/FormElement/FieldsetElement.php
+++ b/src/FormElement/FieldsetElement.php
@@ -108,6 +108,11 @@ class FieldsetElement extends BaseFormElement implements \ipl\Html\Contract\Form
         return parent::setWrapper($wrapper);
     }
 
+    public function isValidEvent($event)
+    {
+        return $event === static::ON_ELEMENT_REGISTERED;
+    }
+
     protected function onElementRegistered(FormElement $element)
     {
         $element->getAttributes()->registerAttributeCallback('name', function () use ($element) {

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -23,6 +23,10 @@ use WeakMap;
 use function ipl\Stdlib\get_php_type;
 
 /**
+ * Classes using this trait must override `isValidEvent` to restrict which
+ * event names are valid. Without an override, `Events::isValidEvent` accepts
+ * any event name unconditionally.
+ *
  * @phpstan-import-type decoratorsFormat from DecoratorChain
  * @phpstan-import-type loaderPaths from DefaultFormElementDecoration
  */
@@ -537,18 +541,6 @@ trait FormElements
         }
 
         return $this;
-    }
-
-    public function isValidEvent($event)
-    {
-        return in_array($event, [
-            Form::ON_SUBMIT,
-            Form::ON_SENT,
-            Form::ON_ERROR,
-            Form::ON_REQUEST,
-            Form::ON_VALIDATE,
-            Form::ON_ELEMENT_REGISTERED,
-        ]);
     }
 
     public function removeElement(string|FormElement $element)

--- a/src/FormElement/FormElements.php
+++ b/src/FormElement/FormElements.php
@@ -252,7 +252,7 @@ trait FormElements
         }
 
         $this->onElementRegistered($element);
-        $this->emit(Form::ON_ELEMENT_REGISTERED, [$element]);
+        $this->emit(static::ON_ELEMENT_REGISTERED, [$element]);
 
         return $this;
     }


### PR DESCRIPTION
`Form` and `FieldsetElement` previously rejected `ON_ASSEMBLED` as an invalid event, causing `on(HtmlDocument::ON_ASSEMBLED, ...)` to throw an `InvalidArgumentException` on both classes. This moves `isValidEvent` out of the `FormElements` trait and into each concrete class so the allowed set can be scoped correctly per class.

`Form` accepts the full set of form lifecycle events plus `ON_ASSEMBLED`. `FieldsetElement` is restricted to `ON_ELEMENT_REGISTERED` and `ON_ASSEMBLED`, the only two events it actually emits. Previously the shared trait list caused `FieldsetElement` to accept events it never dispatches: `ON_SUBMIT`, `ON_SENT`, `ON_ERROR`, `ON_REQUEST`, and `ON_VALIDATE`. Registering listeners for those events would silently do nothing. They now correctly throw. This is a breaking change for any code that registered such listeners on a `FieldsetElement`.

Any future class that uses the `FormElements` trait without providing its own `isValidEvent` override will fall through to `Events::isValidEvent`, which accepts all event names unconditionally. That class must provide its own override to enforce a meaningful restriction. 